### PR TITLE
Initial script to install pyrun and bundle ka-lite inside.

### DIFF
--- a/osx/ka-lite-on-pyrun.sh
+++ b/osx/ka-lite-on-pyrun.sh
@@ -10,18 +10,45 @@
 # . Clone KA-Lite into a directory
 # . Create a kalite binary in `/usr/local/bin/` to use PyRun's Python instead of the system Python.
 # . Modify `<ka-lite-folder>/python.sh` so it uses PyRun`s Python.
+#
+# TODO:
+# * use `tempfile.py` instead of mktemp which is "subject to race conditions"
 
-INSTALL_PYRUN="install-pyrun.sh"
-PYRUN_DIR="/tmp/ka-lite-on-pyrun"
+# TODO(cpauya): get the temp dir of the platform
+# TODO(cpauya): use `mktemp`
+# INSTALL_PYRUN="install-pyrun.sh"
+# PYRUN_DIR="/tmp/ka-lite-on-pyrun"
+# PYRUN="$PYRUN_DIR/bin/pyrun"
+
+# REF: http://stackoverflow.com/questions/3601515/how-to-check-if-a-variable-is-set-in-bash
+if [ -z ${TMPDIR+0} ]; then
+    echo "$TMPDIR is not set..."
+    exit 1
+fi
+
+#BASE_DIR=`basename $0`
+#WORKING_DIR=`mktemp -d -t ${BASE_DIR}.XXX` || exit 1
+#if [ $? -ne 0 ]; then
+#   echo "$0: Can't create temp directory, exiting..."
+#   exit 1
+#fi
+
+# TODO(cpauya): Since we are building a package for ka-lite on pyrun, shouldn't we put
+# this on a more accessible location, like a folder inside the script?
+WORKING_DIR="./"
+echo "Using temporary directory $WORKING_DIR..."
+PYRUN_DIR="$WORKING_DIR/ka-lite-on-pyrun"
+INSTALL_PYRUN="$WORKING_DIR/install-pyrun.sh"
 PYRUN="$PYRUN_DIR/bin/pyrun"
-
 KA_LITE_DIR="$PYRUN_DIR/ka-lite"
 
 # Install PyRun
 echo "Downloading PyRun..."
 curl https://downloads.egenix.com/python/install-pyrun > $INSTALL_PYRUN
+chmod +x $INSTALL_PYRUN
 echo "Installing minimal PyRun..."
 $INSTALL_PYRUN -m --python=2.7 $PYRUN_DIR
 
 # Checkout KA-Lite
 # TODO(cpauya): git clone https://github.com/learningequality/ka-lite.git $KA_LITE_DIR
+git clone https://github.com/learningequality/ka-lite.git $KA_LITE_DIR

--- a/osx/ka-lite-on-pyrun.sh
+++ b/osx/ka-lite-on-pyrun.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Package script for KA-Lite on PyRun
+#
+# Requirements
+# . git
+#
+# Steps
+# . Execute the PyRun installer from https://downloads.egenix.com/python/install-pyrun into a tmp directory.
+# . Clone KA-Lite into a directory
+# . Create a kalite binary in `/usr/local/bin/` to use PyRun's Python instead of the system Python.
+# . Modify `<ka-lite-folder>/python.sh` so it uses PyRun`s Python.
+
+INSTALL_PYRUN="install-pyrun.sh"
+PYRUN_DIR="/tmp/ka-lite-on-pyrun"
+PYRUN="$PYRUN_DIR/bin/pyrun"
+
+KA_LITE_DIR="$PYRUN_DIR/ka-lite"
+
+# Install PyRun
+echo "Downloading PyRun..."
+curl https://downloads.egenix.com/python/install-pyrun > $INSTALL_PYRUN
+echo "Installing minimal PyRun..."
+$INSTALL_PYRUN -m --python=2.7 $PYRUN_DIR
+
+# Checkout KA-Lite
+# TODO(cpauya): git clone https://github.com/learningequality/ka-lite.git $KA_LITE_DIR


### PR DESCRIPTION
Hi @aronasorman - this is the very initial script for #4 

Done:
* It downloads the official PyRun installer script and sets-up a minimal PyRun directory with Python 2.7.8 (more than 25mb) under `/tmp/ka-lite-on-pyrun/`.

ToDos:
* git clone ka-lite on the PyRun tmp folder
* modify ka-lite`s `/scripts/python.sh` script to point to PyRun`s `/bin/pyrun` folder so it uses the Python version of PyRun instead of the system Python.