### PR TITLE
Enable the "Start KA Lite" menu option for unknown statuses.

### DIFF
--- a/osx/KA-Lite Monitor/KA-Lite Monitor/AppDelegate.m
+++ b/osx/KA-Lite Monitor/KA-Lite Monitor/AppDelegate.m
@@ -300,7 +300,7 @@ NSString *getUsernameChars() {
             showNotification(@"Stopped");
             break;
         default:
-            [self.startKalite setEnabled:NO];
+            [self.startKalite setEnabled:YES];
             [self.stopKalite setEnabled:NO];
             [self.openInBrowserMenu setEnabled:NO];
             if (kaliteExists()){

--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -43,13 +43,20 @@ echo "$STEP/$STEPS. Creating temporary directory..."
 
 # TODO(cpauya): Delete when done debugging.  
 # No time to wait for downloads, let's re-use what we have.
-WORKING_DIR="./temp"
+
+# REF: http://stackoverflow.com/a/4774063/845481
+# Reliable way for a bash script to get the full path to itself?
+pushd `dirname $0` > /dev/null
+SCRIPTPATH=`pwd`
+popd > /dev/null
+
+WORKING_DIR="$SCRIPTPATH/temp"
 if ! [ -d "$WORKING_DIR" ]; then
   mkdir "$WORKING_DIR"
 fi
 
-SETUP_FILES_DIR="./setup-files"
-KA_LITE_MONITOR_PROJECT_DIR="./KA-Lite Monitor"
+SETUP_FILES_DIR="$SCRIPTPATH/setup-files"
+KA_LITE_MONITOR_PROJECT_DIR="$SCRIPTPATH/KA-Lite Monitor"
 KA_LITE_MONITOR_DIR="$KA_LITE_MONITOR_PROJECT_DIR/KA-Lite Monitor"
 KA_LITE_MONITOR_RESOURCES_DIR="$KA_LITE_MONITOR_DIR/Resources"
 KA_LITE_MONITOR_APP_PATH="$KA_LITE_MONITOR_PROJECT_DIR/build/Release/KA-Lite Monitor.app"


### PR DESCRIPTION
Hi @aronasorman this fixes #3 - "Mac OS X .app file" issue that doesn't allow the user to click on the "Start KA Lite" menu option on fresh install as reported by @EdDixon during his testing.

This fix will now always enable the "Start KA Lite" menu.

To reproduce the issue:

1. Install the [Mac OS X installer](https://drive.google.com/open?id=0Bwf_-YL9LvlVaGxHX3RxQzVOVzQ&authuser=0) - get the version released 2015-04-06 7:44pm.
1. Go to Terminal and run `touch ~/.kalite/kalite.pid` - this will make the `bin/kalite status` command yield a "Invalid PID file (100)" message 
1. Launch the "KA-Lite Monitor.app" - this will not allow you to click on the "Start KA Lite" menu even when you do another setup or a fresh install.
1. Now install the [Mac OS X installer with fix](https://drive.google.com/open?id=0Bwf_-YL9LvlVaGxHX3RxQzVOVzQ&authuser=0) - get the version released 2015-04-07 3:51pm.
1. Launch the "KA-Lite Monitor.app" and notice that it now allows you to click the "Start KA Lite" menu.

Please note that I manually tested running `bin/kalite start` for the following statuses:

* Unclean shutdown
* KA Lite server configuration error
* Invalid PID file
* Stopped

and that the KA Lite successfully started, thus the fix is just enable the "Start KA Lite" menu.