### PR TITLE
Set environment variables when preferences are applied.

### DIFF
--- a/osx/KA-Lite Monitor/KA-Lite Monitor/en.lproj/MainMenu.xib
+++ b/osx/KA-Lite Monitor/KA-Lite Monitor/en.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6751" systemVersion="14C1510" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="7702" systemVersion="14D136" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6751"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7702"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -92,8 +92,8 @@
             <point key="canvasLocation" x="311" y="144.5"/>
         </window>
         <window title="KA-Lite Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" animationBehavior="default" id="BCW-kl-SX8">
-            <windowStyleMask key="styleMask" titled="YES" unifiedTitleAndToolbar="YES"/>
-            <windowCollectionBehavior key="collectionBehavior" canJoinAllSpaces="YES" participatesInCycle="YES"/>
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" unifiedTitleAndToolbar="YES"/>
+            <windowCollectionBehavior key="collectionBehavior" canJoinAllSpaces="YES" managed="YES" participatesInCycle="YES"/>
             <rect key="contentRect" x="131" y="158" width="493" height="414"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
             <view key="contentView" id="TP3-Cd-o99">


### PR DESCRIPTION
Hi @aronasorman - this initially fixes #30 - Make kalite executable anywhere.

Note: I will just copy the tasks from #30 for reference.

**Tasks**
- [x] Set the `KALITE_DIR` environment variable to the `ka-lite` directory of the .app.
- [x] Set the `KALITE_PYTHON` environment variable to the `PyRun` directory of the .app.
- [ ] Symlink `/usr/local/bin/kalite` to `bin/kalite`
- [ ] Check env vars in Terminal
- [ ] Check env vars in iTerm2
- [ ] Check env vars in .app
- [ ] Check env vars in .app ran with Spotlight

Next step is to do the actual symlink and try to build a .dmg and test the built .app as per tasks above.
