### PR TITLE
Stop the build script if `pip install` failed.

### DIFF
--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -159,6 +159,10 @@ fi
 ((STEP++))
 echo "$STEP/$STEPS. Running '$PYRUN_PIP install -r requirements.txt'... on '$KA_LITE_DIR' "
 $PYRUN_PIP install -r "$KA_LITE_DIR/requirements.txt"
+if [ $? -ne 0 ]; then
+    echo "  $0: Error/s encountered running '$PYRUN_PIP -install -r requirements.txt', exiting..."
+    exit 1
+fi
 
 # Copy the extracted folders to the Xcode Resources folder
 ((STEP++))


### PR DESCRIPTION
Hi @aronasorman - this fixes #40 Stop the build process if pip install failed.

Here is the screenshot if `pip install` failed.
![screenshot 2015-05-11 16 07 55](https://cloud.githubusercontent.com/assets/175580/7560674/ec821c08-f7f7-11e4-8469-527d094e6ecf.png)
