### PR TITLE
Fix for preferences dialog does not show on first run.

### DIFF
--- a/osx/KA-Lite Monitor/KA-Lite Monitor/AppDelegate.m
+++ b/osx/KA-Lite Monitor/KA-Lite Monitor/AppDelegate.m
@@ -42,19 +42,19 @@
     bool mustShowPreferences = false;
     @try {
         NSString *localSettings = getLocalSettingsPath();
-        if (localSettings == nil) {
+        if (!pathExists(localSettings)) {
             NSLog(@"local_settings.py not found, must show preferences...");
             mustShowPreferences = true;
         } else {
-            NSLog(@"FOUND local_settings.py!");
+            NSLog([NSString stringWithFormat:@"FOUND local_settings.py at %@!", localSettings]);
         }
         
         NSString *database = getDatabasePath();
-        if (database == nil) {
+        if (!pathExists(database)) {
             NSLog(@"Database not found, must show preferences.");
             mustShowPreferences = true;
         } else {
-            NSLog(@"FOUND database!");
+            NSLog([NSString stringWithFormat:@"FOUND database at %@!", database]);
         }
         showNotification(@"KA Lite is now loaded.");
     }
@@ -651,7 +651,7 @@ BOOL setEnvVars() {
     
     // Copy `local_settings.default` if no `local_settings.py` was found.
     NSString *localSettingsPath = getLocalSettingsPath();
-    if (localSettingsPath == nil) {
+    if (!pathExists(localSettingsPath)) {
         copyLocalSettings();
     }
 
@@ -662,7 +662,7 @@ BOOL setEnvVars() {
     
     // Automatically run `kalite manage setup` if no database was found.
     NSString *databasePath = getDatabasePath();
-    if (databasePath == nil) {
+    if (!pathExists(databasePath)) {
         if (kaliteExists()) {
             alert(@"Will now run KA-Lite setup, it will take a few minutes.  Please wait until prompted that setup is done.");
             enum kaliteStatus status = [self setupKalite];

--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -159,6 +159,10 @@ fi
 ((STEP++))
 echo "$STEP/$STEPS. Running '$PYRUN_PIP install -r requirements.txt'... on '$KA_LITE_DIR' "
 $PYRUN_PIP install -r "$KA_LITE_DIR/requirements.txt"
+if [ $? -ne 0 ]; then
+    echo "  $0: Error/s encountered running '$PYRUN_PIP -install -r requirements.txt', exiting..."
+    exit 1
+fi
 
 # Copy the extracted folders to the Xcode Resources folder
 ((STEP++))


### PR DESCRIPTION
Hi @aronasorman - this fixes #42 Preferences dialog does not show on first run.

This shows the preferences dialog if the database or `local_settings.py` do not exist.

You can verify output at the `Console` app as per attached screenshot below (look for the "not found, must show preferences" log):
![screenshot 2015-05-12 13 22 47](https://cloud.githubusercontent.com/assets/175580/7580935/9a9369d4-f8af-11e4-97bf-e226e421379f.png)

/cc: @EdDixon 