### PR TITLE
Hotfix/30 make kalite executable anywhere

### DIFF
--- a/osx/KA-Lite Monitor/KA-Lite Monitor/AppDelegate.m
+++ b/osx/KA-Lite Monitor/KA-Lite Monitor/AppDelegate.m
@@ -100,7 +100,6 @@ void copyLocalSettings() {
     if (pathExists(source)) {
         NSString *target;
         NSString *kaliteDir = getKaliteDir(true);
-//        NSLog([NSString stringWithFormat:@"KALITE_DIR 2 == %@", kaliteDir]);
         if (kaliteDir) {
             target = [kaliteDir stringByAppendingString:@"/kalite/local_settings.py"];
         } else {
@@ -136,7 +135,6 @@ NSString *getLocalSettingsPath() {
     } else {
         localSettings = [[NSBundle mainBundle] pathForResource:@"ka-lite/kalite/local_settings" ofType:@"py"];
     }
-//    NSLog([NSString stringWithFormat:@"KALITE_DIR 2 == %@", kaliteDir]);
     return localSettings;
 }
 
@@ -150,7 +148,6 @@ NSString *getDatabasePath() {
     } else {
         database = [[NSBundle mainBundle] pathForResource:@"ka-lite/kalite/database/data" ofType:@"sqlite"];
     }
-//    NSLog([NSString stringWithFormat:@"KALITE_DIR 2 == %@", kaliteDir]);
     return database;
 }
 
@@ -186,7 +183,6 @@ NSString *getKaliteDir(BOOL useEnvVar) {
         }
     }
     kaliteDir = [kaliteDir stringByStandardizingPath];
-//    NSLog([NSString stringWithFormat:@"KALITE_DIR 2 == %@", kaliteDir]);
     if (pathExists(kaliteDir)){
         return kaliteDir;
     }
@@ -218,7 +214,6 @@ NSString *getPyrunBinPath(BOOL useEnvVar) {
         }
     }
     pyrun = [pyrun stringByStandardizingPath];
-//    NSLog([NSString stringWithFormat:@"KALITE_PYTHON 2 == %@", pyrun]);
     if (pathExists(pyrun)){
         return pyrun;
     }
@@ -483,7 +478,6 @@ NSDictionary *runAsRoot(NSString *command) {
 NSString *getEnvVar(NSString *var) {
     // Get environment variables as per var argument.
     NSString *path = [[[NSProcessInfo processInfo]environment]objectForKey:var];
-//    NSLog([NSString stringWithFormat:@"ENV VAR: %@ == %@", var, path]);
     return path;
 }
 

--- a/osx/KA-Lite Monitor/KA-Lite Monitor/Info.plist
+++ b/osx/KA-Lite Monitor/KA-Lite Monitor/Info.plist
@@ -24,6 +24,8 @@
 	<string>1</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.education</string>
+	<key>LSEnvironment</key>
+	<dict/>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/osx/README.md
+++ b/osx/README.md
@@ -24,6 +24,7 @@ There are two ways to build the installer, automated or manually.
     1.6. Build the `KA-Lite Monitor.dmg` package.  The output can be found at the `temp/output/KA-Lite Monitor.dmg`.
 2. To build the .dmg manually - refer to the README-FOR-DMG.md document.
 
+
 ### To manually build and test the application
 
 1. Run `setup.sh` so it will download the `ka-lite` repository and `pyrun`.
@@ -41,3 +42,10 @@ There are two ways to build the installer, automated or manually.
 
     * KA-Lite repo on `develop` branch
     * PyRun version 2.7
+
+
+## References
+
+1. [??? Installing Tomcat on Mac OS X](http://www.joel.lopes-da-silva.com/2008/05/13/installing-tomcat-on-mac-os-x/)
+1. [??? Using launchd](http://trac.buildbot.net/wiki/UsingLaunchd)
+1. [??? HowTo: Set an Environment Variable in Mac OS X](http://www.dowdandassociates.com/blog/content/howto-set-an-environment-variable-in-mac-os-x/)


### PR DESCRIPTION
Hi @aronasorman - this fixes #30 Make kalite executable anywhere.

Specifically, this resolves the issue where a restart of the computer resets the `KALITE_DIR` and `KALITE_PYTHON` environment variables.

What we do here are:

1. Create a .plist at `/Library/LaunchDaemons/org.learningequality.kalite.plist` that will set the above environment variables to the install location of KA Lite and Pyrun on boot.
2. Create a symlink of the kalite executable to `/usr/local/bin/kalite` which needs the above environment variables.

I haven't fully tested it yet but it has enough functionality for some feedback from @EdDixon specially if we can build the installer with content, the one that's about 400mb+ in size.