### PR TITLE
Fix the issue where the environment variables are not set when running the kalite command.

### DIFF
--- a/osx/KA-Lite Monitor/KA-Lite Monitor/AppDelegate.m
+++ b/osx/KA-Lite Monitor/KA-Lite Monitor/AppDelegate.m
@@ -572,7 +572,7 @@ BOOL setEnvVars(BOOL createPlist) {
      */
     NSString *org = @"org.learningequality.kalite";
     NSString *path = [NSString stringWithFormat:@"/tmp/%@.plist", org];
-    NSString *target = [NSString stringWithFormat:@"/Library/LaunchDaemons/%@.plist", org];
+    NSString *target = [NSString stringWithFormat:@"/Library/LaunchAgents/%@.plist", org];
     NSMutableDictionary *plistDict = [[NSMutableDictionary alloc] init];
     [plistDict setObject:org forKey:@"Label"];
     NSString *launchStr = [NSString stringWithFormat:@"%@;%@",

--- a/osx/KA-Lite Monitor/KA-Lite Monitor/AppDelegate.m
+++ b/osx/KA-Lite Monitor/KA-Lite Monitor/AppDelegate.m
@@ -274,8 +274,7 @@ BOOL pyrunExists() {
         // because the .app may be loaded the first time.
         kaliteCmd = [NSString stringWithFormat: @"export KALITE_DIR=\"%@\"; export KALITE_PYTHON=\"%@\"; \"%@\"",
                      kaliteDir, pyrun, kalitePath];
-        
-        kaliteCmd = [NSString stringWithFormat: @"\"%@\"", kalitePath];
+        NSLog([NSString stringWithFormat:@"COMMAND ==> %@", kaliteCmd]);
         
         finalCmd = [NSString stringWithFormat:@"%@ %@", kaliteCmd, command];
         statusCmd = [NSString stringWithFormat:@"%@ %@", kaliteCmd, @"status"];


### PR DESCRIPTION
Hi @aronasorman - this fixes #30 Make kalite executable anywhere.

It now starts the KA-Lite server properly from the icon or from the terminal with the `kalite` command.

I'm gonna do more testing with restarts to see if it still works.