### PR TITLE
Install pip dependencies when running ka lite windows installer

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -17,10 +17,17 @@ This project provides a smoother way to install and run KA Lite in a Windows Mac
 * Click on Update.
 
 ---
-#### Instructions to build "KALiteSetup.exe" in Windows:
+#### Instructions to download pip dependency zip files.
 * Clone the `ka-lite` repository.
-* Clone this repository;
-* Copy `ka-lite` folder from `ka-lite` repository, to the `installers/windows` of this repository;
+* Clone this repository.
+* Install `python-2.7.10.msi` at `/installer/windows/python-setup` directory.
+* Add `python path` to your windows Environment Variables.
+* On your command line navigate to `ka-lite` directory that contain `setup.py`.
+* Run this command `python setup.py sdist --static` to download zip files .
+
+---
+#### Instructions to build "KALiteSetup.exe" in Windows:
+* Copy `ka-lite` directory from `ka-lite` repository, to the `installers/windows` of this repository;
 * Run `installers/windows/make.vbs` and wait until the output file is built;
 * The output file named "KALiteSetup-X.X.X.exe" will appear within this project folder.
 
@@ -28,7 +35,6 @@ This project provides a smoother way to install and run KA Lite in a Windows Mac
 #### To clone ka-lite and this repository, run the following line:
 * git clone https://github.com/learningequality/ka-lite.git
 * git clone https://github.com/learningequality/installers.git
-####
 
 ---
 ##### Instructions to build "KALiteSetup-X.X.X.exe" in Linux:

--- a/windows/README.md
+++ b/windows/README.md
@@ -11,26 +11,24 @@ This project provides a smoother way to install and run KA Lite in a Windows Mac
 
 ---
 #### Instructions to update Microsoft Visual Studio 2012
-###### Steps to update:
+##### Steps to update:
 * Click on TOOLS menu
 * Select Extensions and Updates... then another dialog will appear.
 * Click on Update.
 
-###### Install the downloaded update in your machine
-* Click on BUILD.
-* Select Build Solution.
-
 ---
 #### Instructions to build "KALiteSetup.exe" in Windows:
+* Clone the `ka-lite` repository.
 * Clone this repository;
-* Copy `ka-lite` folder from KA Lite's repository, to the root of this repository;
-* Run `make.vbs` and wait until the output file is built;
+* Copy `ka-lite` folder from `ka-lite` repository, to the `installers/windows` of this repository;
+* Run `installers/windows/make.vbs` and wait until the output file is built;
 * The output file named "KALiteSetup-X.X.X.exe" will appear within this project folder.
 
 ---
-##### To clone this repository, run the following line:
-    git clone https://github.com/learningequality/installers.git
-######
+#### To clone ka-lite and this repository, run the following line:
+* git clone https://github.com/learningequality/ka-lite.git
+* git clone https://github.com/learningequality/installers.git
+####
 
 ---
 ##### Instructions to build "KALiteSetup-X.X.X.exe" in Linux:

--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -325,7 +325,7 @@ procedure HandlePythonSetup;
 var
     installPythonErrorCode : Integer;
 begin
-    if(MsgBox('Python error' #13#13 'Python 2.6+ is required to run KA Lite; do you wish to first install Python 2.7.9, before continuing with the installation of KA Lite?', mbConfirmation, MB_YESNO) = idYes) then
+    if(MsgBox('Python error' #13#13 'Python 2.6+ is required to run KA Lite; do you wish to first install Python 2.7.10, before continuing with the installation of KA Lite?', mbConfirmation, MB_YESNO) = idYes) then
     begin
         ExtractTemporaryFile('python-2.7.10.msi');
         ShellExec('open', ExpandConstant('{tmp}')+'\python-2.7.10.msi', '', '', SW_SHOWNORMAL, ewWaitUntilTerminated, installPythonErrorCode);
@@ -334,6 +334,25 @@ begin
         MsgBox('Error' #13#13 'You must have Python 2.6+ installed to proceed! Installation will now exit.', mbError, MB_OK);
         forceCancel := True;
         WizardForm.Close;
+    end;
+end;
+
+procedure HandlePipSetup;
+var
+    PipCommand: string;
+    PipPath: string;
+    ErrorCode: integer;
+
+begin
+    PipPath := 'C:\Python27\Scripts\pip.exe';
+    PipCommand := 'install ' + '"' + ExpandConstant('{app}') + '\ka-lite\dist\ka-lite-static-0.14.dev10.zip' + '"';
+
+    MsgBox('Setup will now configure Pip dependencies.', mbInformation, MB_OK);
+    if not ShellExec('open', PipPath, PipCommand, '', SW_HIDE, ewWaitUntilTerminated, ErrorCode) then
+    begin
+      MsgBox('Critical error.' #13#13 'Pip dependemcies has failed to install. Error Number:' + IntToStr(ErrorCode), mbInformation, MB_OK);
+      forceCancel := True;
+      WizardForm.Close;
     end;
 end;
 
@@ -434,6 +453,7 @@ begin
     begin
         if installFlag then
         begin
+            HandlePipSetup();
             setupCommand := 'manage.py setup --noinput -o "'+ServerInformationPage.Values[0]+'" -d "'+ServerInformationPage.Values[1]+'" -u "'+UserInformationPage.Values[0]+'" -p "'+UserInformationPage.Values[1]+'"';
             
             MsgBox('Setup will now configure the database. This operation may take a few minutes. Please be patient.', mbInformation, MB_OK);

--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -327,8 +327,8 @@ var
 begin
     if(MsgBox('Python error' #13#13 'Python 2.6+ is required to run KA Lite; do you wish to first install Python 2.7.9, before continuing with the installation of KA Lite?', mbConfirmation, MB_YESNO) = idYes) then
     begin
-        ExtractTemporaryFile('python-2.7.9.msi');
-        ShellExec('open', ExpandConstant('{tmp}')+'\python-2.7.9.msi', '', '', SW_SHOWNORMAL, ewWaitUntilTerminated, installPythonErrorCode);  
+        ExtractTemporaryFile('python-2.7.10.msi');
+        ShellExec('open', ExpandConstant('{tmp}')+'\python-2.7.10.msi', '', '', SW_SHOWNORMAL, ewWaitUntilTerminated, installPythonErrorCode);
     end
     else begin
         MsgBox('Error' #13#13 'You must have Python 2.6+ installed to proceed! Installation will now exit.', mbError, MB_OK);


### PR DESCRIPTION
Hi @aronasorman this fixes #53 

I updated the `python` installer version from `2.7.9` to `2.7.10` so that the `pip` will update also from `1.5.4` to `7.0.1`.

This is where the kalite  zip files are extracted.
![screen shot 2015-06-06 at 1 50 10 am](https://cloud.githubusercontent.com/assets/8663934/8011783/6e68a84a-0bee-11e5-8069-e7998a2cbe64.png)

