### PR TITLE
Windows installer - don't assume drive letter for `pip.exe`

### DIFF
--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -193,6 +193,8 @@ if ! [ -d "$KA_LITE_MONITOR_APP_PATH" ]; then
 fi
 
 # sign the .app file
+# unlock the keychain first so we can access the private key
+security unlock-keychain -p $KEYCHAIN_PASSWORD
 codesign -s "Foundation for Learning Equality, Inc." --force "$KA_LITE_MONITOR_APP_PATH"
 
 # Build the .dmg file.
@@ -235,6 +237,8 @@ $CREATE_DMG \
 echo "Done!"
 if [ -e "$DMG_PATH" ]; then
     # codesign the built DMG file
+    # unlock the keychain first so we can access the private key
+    security unlock-keychain -p $KEYCHAIN_PASSWORD
     codesign -s "Foundation for Learning Equality, Inc." --force "$DMG_PATH"
     echo "You can now test the built installer at '$DMG_PATH'."
 else

--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -417,6 +417,38 @@ begin
     end;
 end;
 
+{ Used in GetPipPath below }
+const
+    DEFAULT_PATH = '\Python27\Scripts\pip.exe';
+
+{ Returns the path of pip.exe on the system. }
+{ Tries several different locations before prompting user. }
+function GetPipPath: string;
+var
+    path : string;
+    i : integer;
+begin
+    for i := Ord('C') to Ord('H') do
+    begin
+        path := Chr(i) + ':' + DEFAULT_PATH;
+        if FileExists(path) then
+        begin
+            Result := path;
+            exit;
+        end;
+    end;
+    MsgBox('Could not find pip.exe. Please select the location of pip.exe to continue installation.', mbInformation, MB_OK);
+    if GetOpenFileName('Please select pip.exe', path, '', 'All files (*.*)|*.*', 'exe') then
+    begin
+        Result := path;
+    end
+    else begin
+        MsgBox('Fatal error'#13#13'Please install pip and try again.', mbError, MB_OK);
+        forceCancel := True;
+        Result := '';
+    end;
+end;
+
 procedure HandlePipSetup;
 var
     PipCommand: string;
@@ -424,12 +456,13 @@ var
     ErrorCode: integer;
 
 begin
-    { Don't specify drive letter. Just let "start" figure it out below. }
-    PipPath := '\Python27\Scripts\pip.exe';
-    PipCommand := 'install ' + '"' + ExpandConstant('{app}\ka-lite\dist\ka-lite-static-')  + '{#TargetVersion}' + '.zip' + '"';
+    PipPath := GetPipPath;
+    if PipPath = '' then
+        exit;
+    PipCommand := 'install "' + ExpandConstant('{app}\ka-lite\dist\ka-lite-static-')  + '{#TargetVersion}' + '.zip"';
 
     MsgBox('Setup will now unpack dependencies for your installation.', mbInformation, MB_OK);
-    if not Exec(ExpandConstant('{cmd}'), '/S /C "start /b ' + PipPath + ' ' + PipCommand + '"', '', SW_HIDE, ewWaitUntilTerminated, ErrorCode) then
+    if not ShellExec('open', PipPath, PipCommand, '', SW_HIDE, ewWaitUntilTerminated, ErrorCode) then
     begin
       MsgBox('Critical error.' #13#13 'Dependencies have failed to install. Error Number: ' + IntToStr(ErrorCode), mbInformation, MB_OK);
       forceCancel := True;
@@ -571,7 +604,7 @@ begin
             begin
                 DoGitMigrate;
             end
-            else
+            else if Not forceCancel then
             begin
                 DoSetup;
             end;

--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -424,13 +424,14 @@ var
     ErrorCode: integer;
 
 begin
-    PipPath := 'C:\Python27\Scripts\pip.exe';
+    { Don't specify drive letter. Just let "start" figure it out below. }
+    PipPath := '\Python27\Scripts\pip.exe';
     PipCommand := 'install ' + '"' + ExpandConstant('{app}\ka-lite\dist\ka-lite-static-')  + '{#TargetVersion}' + '.zip' + '"';
 
-    MsgBox('Setup will now configure Pip dependencies.', mbInformation, MB_OK);
-    if not ShellExec('open', PipPath, PipCommand, '', SW_HIDE, ewWaitUntilTerminated, ErrorCode) then
+    MsgBox('Setup will now unpack dependencies for your installation.', mbInformation, MB_OK);
+    if not Exec(ExpandConstant('{cmd}'), '/S /C "start /b ' + PipPath + ' ' + PipCommand + '"', '', SW_HIDE, ewWaitUntilTerminated, ErrorCode) then
     begin
-      MsgBox('Critical error.' #13#13 'Pip dependencies have failed to install. Error Number:' + IntToStr(ErrorCode), mbInformation, MB_OK);
+      MsgBox('Critical error.' #13#13 'Dependencies have failed to install. Error Number: ' + IntToStr(ErrorCode), mbInformation, MB_OK);
       forceCancel := True;
       WizardForm.Close;
     end;


### PR DESCRIPTION
Handles the case where `pip.exe` is not on the `C:` drive. Fixes #74 and fixes #81. Will test out on Windows 8. @radinamatic I'll upload an installer for you to try, as well.