### PR TITLE
Windows - root data path fix

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -40,6 +40,7 @@ To build in Linux, first install `wine`.
 * Ensure the assessment items have been unpacked in the `ka-lite` directory.
 * Follow the _Instructions to download pip dependency zip files_ above
 * Create an empty db for distribution as per the section _Creating an Empty DB_
+* Run `kalite manage collectstatic` to create the `ka-lite/static-libraries` directory; this is a work-around until the windows installer uses setuptools.
 * In Windows, run the following command from this directory:
 ```
 > make.vbs

--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -600,6 +600,15 @@ begin
         begin
             HandlePipSetup();
 
+            { Add KALITE_ROOT_DATA_PATH to environment variables. A workaround for setting kalite.ROOT_DATA_PATH }
+            { In the future, the windows installer should use setuptools to avoid OS-dependent workarounds like this. }
+            RegWriteStringValue(
+                HKLM,
+                'System\CurrentControlSet\Control\Session Manager\Environment',
+                'KALITE_ROOT_DATA_PATH',
+                ExpandConstant('{app}\ka-lite\')
+            );
+
             { Migrate old database if applicable, otherwise create a new one }
             if runGitmigrate and Not forceCancel then
             begin

--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -28,6 +28,7 @@ Compression=lzma
 SolidCompression=yes
 PrivilegesRequired=admin
 UsePreviousAppDir=yes
+ChangesEnvironment=yes
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"


### PR DESCRIPTION
Update the installer to set the `ROOT_DATA_PATH` by environment variable. Also add instructions for building the installer. It's necessary to run collectstatic so that static-libraries are copied over... User might not have the permissions to create the static-directory after install. This handles both a new install and an upgrade case.