### PR TITLE
Hotfix/26 deploy ka lite data folders to another location outside of the app

### DIFF
--- a/osx/KA-Lite Monitor/KA-Lite Monitor.xcodeproj/project.pbxproj
+++ b/osx/KA-Lite Monitor/KA-Lite Monitor.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		F103615C1A81B7DF00998E6B /* images in Resources */ = {isa = PBXBuildFile; fileRef = F103615B1A81B7DF00998E6B /* images */; };
 		F1720BED1A79566700096453 /* README.md in Sources */ = {isa = PBXBuildFile; fileRef = F1720BEC1A79566700096453 /* README.md */; };
 		F1720BF11A7A343A00096453 /* local_settings.default in Resources */ = {isa = PBXBuildFile; fileRef = F1720BF01A7A343A00096453 /* local_settings.default */; };
-		F1B308371ACBD08400008AF1 /* ka-lite in Resources */ = {isa = PBXBuildFile; fileRef = F1B308361ACBD08300008AF1 /* ka-lite */; };
 		F1B308391ACBD09500008AF1 /* pyrun-2.7 in Resources */ = {isa = PBXBuildFile; fileRef = F1B308381ACBD09400008AF1 /* pyrun-2.7 */; };
 		F1DDD4131A6E5DC10022F1C9 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = F1DDD4121A6E5DC10022F1C9 /* AppDelegate.m */; };
 		F1DDD4151A6E5DC10022F1C9 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = F1DDD4141A6E5DC10022F1C9 /* main.m */; };
@@ -33,9 +32,7 @@
 		F103615B1A81B7DF00998E6B /* images */ = {isa = PBXFileReference; lastKnownFileType = folder; name = images; path = Resources/images; sourceTree = "<group>"; };
 		F1720BEC1A79566700096453 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		F1720BF01A7A343A00096453 /* local_settings.default */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = local_settings.default; sourceTree = "<group>"; };
-		F1B308321ACBA99300008AF1 /* ka-lite */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "ka-lite"; path = "KA-Lite Monitor/Resources/ka-lite"; sourceTree = "<group>"; };
 		F1B308341ACBAA2B00008AF1 /* pyrun-2.7 */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "pyrun-2.7"; path = "KA-Lite Monitor/Resources/pyrun-2.7"; sourceTree = "<group>"; };
-		F1B308361ACBD08300008AF1 /* ka-lite */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "ka-lite"; path = "Resources/ka-lite"; sourceTree = "<group>"; };
 		F1B308381ACBD09400008AF1 /* pyrun-2.7 */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "pyrun-2.7"; path = "Resources/pyrun-2.7"; sourceTree = "<group>"; };
 		F1DDD40C1A6E5DC10022F1C9 /* KA-Lite Monitor.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "KA-Lite Monitor.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F1DDD4101A6E5DC10022F1C9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -71,7 +68,6 @@
 			isa = PBXGroup;
 			children = (
 				F1B308341ACBAA2B00008AF1 /* pyrun-2.7 */,
-				F1B308321ACBA99300008AF1 /* ka-lite */,
 				F1DDD40E1A6E5DC10022F1C9 /* KA-Lite Monitor */,
 				F1DDD4221A6E5DC10022F1C9 /* KA-Lite MonitorTests */,
 				F1DDD40D1A6E5DC10022F1C9 /* Products */,
@@ -103,7 +99,6 @@
 			isa = PBXGroup;
 			children = (
 				F1B308381ACBD09400008AF1 /* pyrun-2.7 */,
-				F1B308361ACBD08300008AF1 /* ka-lite */,
 				F103615B1A81B7DF00998E6B /* images */,
 				F1720BF01A7A343A00096453 /* local_settings.default */,
 				F1DDD4101A6E5DC10022F1C9 /* Info.plist */,
@@ -212,7 +207,6 @@
 			files = (
 				F103615C1A81B7DF00998E6B /* images in Resources */,
 				F1B308391ACBD09500008AF1 /* pyrun-2.7 in Resources */,
-				F1B308371ACBD08400008AF1 /* ka-lite in Resources */,
 				F1DDD4171A6E5DC10022F1C9 /* Images.xcassets in Resources */,
 				F1E5A30B1A8041FD003FA650 /* MainMenu.xib in Resources */,
 				F1720BF11A7A343A00096453 /* local_settings.default in Resources */,

--- a/osx/KA-Lite Monitor/KA-Lite Monitor/README.md
+++ b/osx/KA-Lite Monitor/KA-Lite Monitor/README.md
@@ -16,25 +16,26 @@ To install:
 1. Logs terminal messages so they are accessible at the Console app.
 
 
-## Use of the .app
+## Use of the app
 
-The .app shows an icon at the system status menu and a Preferences dialog as it's interfaces.
+When the app is run, it will automatically show the preferences dialog if the following do not exist:
 
-The .app uses User Preferences saved at `~/Library/Preferences/FLE.KA-Lite-Monitor.plist` to save the following:
+1. `/usr/bin/kalite` symlink
+2. database at `~/.kalite/database/data.sqlite` - the `~/.kalite/` location can be overridden by setting a `KALITE_HOME` environment variable
+
+The app shows an icon at the system status menu and it uses User Preferences saved at `~/Library/Preferences/FLE.KA-Lite-Monitor.plist` to save the following:
 
 1. admin username
 2. admin password (encoded)
-3. (TODO) KALITE_DIR environment variable - defaults to the `<Resources directory>/ka-lite/` folder.
-4. (TODO) KALITE_PYTHON environment variable - defaults to the `<Resources directory>/pyrun-2.7/bin/pyrun`.
+3. (TODO) KALITE_PYTHON environment variable - defaults to the `<Resources directory>/pyrun-2.7/bin/pyrun`.
 
-When the .app is run, it will automatically show the preferences dialog if the following do not exist:
-
-* database at `KALITE_DIR/kalite/database/data.sqlite`
-* local settings at `KALITE_DIR/kalite/local_settings.py`
+Note that the "Start KA Lite" menu is disabled if the `/usr/bin/kalite` cannot be found.
 
 
 ### Use of the preferences dialog
 
-When the `Apply` button is clicked, the .app will ask for an admin password so it can symlink the `KALITE_DIR/bin/kalite` executable to `/usr/local/bin/kalite` to make it runnable from anywhere on the Mac.
+When the `Apply` button is clicked, the app will ask for an admin password so it can symlink the `<pyrun-directory>/bin/kalite` executable to `/usr/bin/kalite` to make it runnable from anywhere on the Mac.
 
-Click on the `Setup` button at the `Advanced` tab to repeat the setup process.  This will call `kalite manage setup --username %@ --password %@ --noinput` with the username and password values coming from the textboxes.
+Click on the `Setup` button at the `Advanced` tab to repeat the setup process.  This will call `kalite manage setup --username=%@ --password=%@ --noinput` with the username and password values coming from the textboxes.
+
+The `Reset App` button at the `Advanced` tab will reset all files/settings as if the app was never installed.

--- a/osx/KA-Lite Monitor/KA-Lite Monitor/en.lproj/MainMenu.xib
+++ b/osx/KA-Lite Monitor/KA-Lite Monitor/en.lproj/MainMenu.xib
@@ -354,10 +354,10 @@ Gw
                                                             <string key="title">WARNING:  Do this only if you know what you are doing.  
 
 This will remove the installer files to set a clean environment:
-1. remove the KALITE_PYTHON environment variable
-2. delete the .plist file which auto-sets the above env var
-3. delete the symlinked /usr/local/bin/kalite executable
-4. (TODO) delete the stored user preferences
+1. Remove the KALITE_PYTHON environment variable.
+2. Delete the /Library/LaunchAgents/org.learningequality.kalite.plist file which auto-sets the above env var on computer boot.
+3. Delete the symlinked /usr/bin/kalite executable.
+4. Delete the stored user preferences.
 
 Click the Apply button to re-create the installation files mentioned above.</string>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>

--- a/osx/KA-Lite Monitor/KA-Lite Monitor/en.lproj/MainMenu.xib
+++ b/osx/KA-Lite Monitor/KA-Lite Monitor/en.lproj/MainMenu.xib
@@ -354,8 +354,8 @@ Gw
                                                             <string key="title">WARNING:  Do this only if you know what you are doing.  
 
 This will remove the installer files to set a clean environment:
-1. remove the KALITE_DIR and KALITE_PYTHON environment variables
-2. delete the .plist file which auto-sets the above env vars
+1. remove the KALITE_PYTHON environment variable
+2. delete the .plist file which auto-sets the above env var
 3. delete the symlinked /usr/local/bin/kalite executable
 4. (TODO) delete the stored user preferences
 

--- a/osx/README.md
+++ b/osx/README.md
@@ -5,9 +5,9 @@ This folder contains the script and sources to build the installer for KA-Lite.
 The application icon sits on the status menu of OS X and uses [PyRun](http://www.egenix.com/products/python/PyRun/) instead of the OS X built-in Python.
 
 
-## Requirements
+## System Requirements
 
-* OS X 10.10 Yosemite
+* Mac OSX 10.10 Yosemite
 * git
 * Xcode 6.1.x
 
@@ -17,9 +17,9 @@ There are two ways to build the installer, automated or manually.
 
 1. To build automatically, run `setup.sh` which will:
     1.1. Create a `temp` directory (this is ignored in the .gitignore) and puts everything else inside it.
-    1.2. Download PyRun to the `pyrun-2.7` directory.
-    1.3. Download the KA-Lite source to the `ka-lite` directory.
-    1.4. Copy the `pyrun-2.7` and `ka-lite` directories to the `<xcode_source>/Resources/` folder.
+    1.2. Download PyRun to the `temp/pyrun-2.7` directory.
+    1.3. Download the KA-Lite source to the `temp/ka-lite` directory.
+    1.4. Copy the `pyrun-2.7` directory to the `<xcode_source>/Resources/` folder.
     1.5. Build the `KA-Lite Monitor.app` using `xcodebuild`.
     1.6. Build the `KA-Lite Monitor.dmg` package.  The output can be found at the `temp/output/KA-Lite Monitor.dmg`.
 2. To build the .dmg manually - refer to the README-FOR-DMG.md document.
@@ -30,18 +30,25 @@ There are two ways to build the installer, automated or manually.
 1. Run `setup.sh` so it will download the `ka-lite` repository and `pyrun`.
 2. Launch Xcode
 3. At the Project Navigator (left-pane), right-click on the Supporting Files folder and select Add Files to "KA Lite Monitor".
-4. Select the `pyrun-2.7` and `ka-lite` directories that were copied at the Resources folder by `setup.sh` above.  Make sure to select "Create folder references."!
+4. Select the `pyrun-2.7` directory that was copied at the Resources folder by `setup.sh` above.  Make sure to select "Create folder references."!
 5. Build the project to produce the .app.
 
 
 ## Notes
 
+1. Please note that this has been tested on Mac OSX 10.10 Yosemite.  It may run on older versions down to Mac OSX Mountain Lion 10.8 but we haven't tested it.
 1. The `setup-files` folder contains the files to be included on the dmg file.
 1. The `ka-lite-pencil.ep` is the [Pencil](https://code.google.com/p/evoluspencil/) file to generate the background image of the dmg file.
 1. `setup.sh` downloads the following
 
-    * KA-Lite repo on `develop` branch
+    * KA-Lite repo on `develop` branch, or the specified repo
     * PyRun version 2.7
+1. You can optionally pass a ka-lite archive repo url as an argument in this format:
+
+    > ./setup.sh "https://github.com/learningequality/ka-lite/archive/0.14.x.zip"
+
+    This is useful if you want to try a different fork or branch on your build.
+    It defaults to the `develop` branch at "https://github.com/learningequality/ka-lite/archive/develop.zip".
 
 
 ## References

--- a/osx/setup-files/README.md
+++ b/osx/setup-files/README.md
@@ -1,50 +1,59 @@
-KA-Lite Monitor OS X App
-========================
+KA-Lite Monitor Mac OSX App
+===========================
 
-This is the KA-Lite Monitor application that sits on the status menu of OS X.  
+This is the KA-Lite Monitor application that sits on the status menu of Mac OSX.  
 
-It also contains the source for [KA-Lite](https://github.com/learningequality/ka-lite/).
+It's used to install and monitor the [KA-Lite](https://github.com/learningequality/ka-lite/) server by [Foundation for Learning Equality](https://learningequality.org/).
+
+It uses [PyRun](http://www.egenix.com/products/python/PyRun/) to isolate the KA-Lite environment from your system's [Python](https://www.python.org/) application.
 
 
-## To install:
+## To Install
 
-1. Drag the "KA-Lite Monitor" app into the "Applications" folder.
+1. Open the downloaded "KA-Lite Monitor.dmg" package.
+1. On the .dmg window, drag the "KA-Lite Monitor" app into the "Applications" folder.
 1. Launch "KA-Lite Monitor" from your 'Applications' folder.
 1. On first load, it will check for some settings and prompt for the Preferences dialog.
 1. Input your preferred admin username and password.
 1. Click on the Apply button.
 1. You will be prompted that initial setup will take a few minutes, just click on Ok button and wait for the prompt that KA-Lite has been setup and can now be started.
-1. Click on the KA-Lite logo icon on the Status Bar and select the "Start KA-Lite" menu option.
+1. Click on the KA-Lite logo icon on the Status Menu Bar and select the "Start KA-Lite" menu option.
 1. When prompted that KA-Lite has been started, click on the logo icon again and select "Open in Browser" menu option - this should launch KA-Lite on your preferred web browser.
 1. Login using the administrator account you have specified during setup.
 
 
-## Operations
+## Menu Options
 
 1. Start KA Lite == Starts the KA-Lite web server.
 1. Stop KA Lite == Stops the KA-Lite web server.
 1. Open in Browser == Opens the installed KA-Lite web app using your preferred web browser, usually at http://127.0.0.1:8008.
-1. Preferences == Opens the preferences window where you can customize the admin account or repeat the setup process.
+1. Preferences == Opens the preferences window where you can customize the admin account, repeat the setup process, or reset the app on the Advanced tab.
 1. Quit == Stops the KA-Lite web server and closes the application.
 
 
 ## Advanced Notes
 
-1. On the `Advanced` tab, you can click on the `Setup` button which will re-setup your KA-Lite installation.  This will take a few minutes and be careful because you may lose data!
-1. If you want to access the KA-Lite source:
-    1.1. Right-click on the "KA-Lite Monitor.app" on your `Applications` folder.
-    1.2. Select `Show Package Contents -> Contents -> Resources`.
-    1.3. The `ka-lite` folder contains the source code of KA-Lite.
-    1.4. The `pyrun-2.7` folder contains [PyRun](http://www.egenix.com/products/python/PyRun/) that is used to isolate KA-Lite from your system's Python application.
+1. You can use the `kalite` executable at the Terminal for advanced commands.
 1. If you want to access/backup the KA-Lite database:
-    1.1. Right-click on the "KA-Lite Monitor.app" on your `Applications` folder.
-    1.2. Select `Show Package Contents -> Contents -> Resources -> ka-lite -> kalite -> database`.
-    1.3. Copy the `data.sqlite` to your preferred location.  This is a [Sqlite](https://sqlite.org/) database.
+    1.1. Go to the `~/.kalite/database/` folder.
+    1.2. Copy the `data.sqlite` to your preferred location.  This is a [Sqlite](https://sqlite.org/) database.
+1. If you want to access/backup your contents like videos and assessment items:
+    1.1. Go to the `~/.kalite/content/` folder.
+    1.2. Copy the contents to your preferred location.
+1. We suggest you make a backup of your installation contents at `~/.kalite/` before using the controls at the `Advanced` tab.
+1. On the `Advanced` tab, you can click on the `Setup` button which will re-setup your KA-Lite installation.  This will take a few minutes and be careful because you may lose data!
+1. Also on the `Advanced` tab, there's a `Reset App` button that will clear settings and files that were created by the app.  This will set the KA-Lite environment as if the app was not yet installed.  Please be very careful with this button and only use this in case you encounter issues in your installation.
 
 
-## Help
+## Help and Logs
 
-1. To view the KA-Lite Monitor's application logs (for debugging or tracing), launch the `Console` application and filter by "ka-lite".
+To view the KA-Lite Monitor's application logs (for debugging or tracing), launch the `Console` application and filter by "ka-lite".
+
+You can also open `~/.kalite/server.log` to view access and debug logs of the KA-Lite server.
+
+If you encounter issues, please file them at the [KA-Lite Installers repository](https://github.com/learningequality/installers).
+
+Please note that we have tested this application on MAC OSX Yosemite 10.10.x.
 
 
 ## ToDos

--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -80,14 +80,8 @@ KA_LITE_ZIP="$WORKING_DIR/$KA_LITE.zip"
 KA_LITE_DIR="$WORKING_DIR/$KA_LITE"
 KA_LITE_REPO_ZIP="https://github.com/$GITHUB_ACCOUNT/ka-lite/zipball/develop/"
 KA_LITE_REPO_ZIP="https://github.com/$GITHUB_ACCOUNT/ka-lite/zipball/hotfix/3704-cannot-connect-to-server-for-downloading-video-files-from-current-development-installs"
-KA_LITE_EXECUTABLE="$KA_LITE_MONITOR_RESOURCES_DIR/$KA_LITE/kalite/bin/kalite"
-KA_LITE_SOURCE_DIR_FILE="$KA_LITE_DIR/.KALITE_SOURCE_DIR"
 
-KA_LITE_MONITOR_RESOURCES_KA_LITE_DIR="$KA_LITE_MONITOR_RESOURCES_DIR/$KA_LITE"
 KA_LITE_MONITOR_RESOURCES_PYRUN_DIR="$KA_LITE_MONITOR_RESOURCES_DIR/$PYRUN_NAME"
-
-LOCAL_SETTINGS_DEFAULT_PATH="$KA_LITE_MONITOR_DIR/local_settings.default"
-LOCAL_SETTINGS_TARGET_PATH="$KA_LITE_DIR/kalite/local_settings.py"
 
 OUTPUT_PATH="$WORKING_DIR/output"
 DMG_PATH="$OUTPUT_PATH/KA-Lite Monitor.dmg"
@@ -156,46 +150,25 @@ else
     mv $WORKING_DIR/$GITHUB_ACCOUNT* $KA_LITE_DIR
 fi
 
-# Make the ka-lite repo production ready...
-((STEP++))
-echo "$STEP/$STEPS. Making the ka-lite repo production ready..."
-if [ -e "$KA_LITE_SOURCE_DIR_FILE" ]; then
-    echo "  Deleting $KA_LITE_SOURCE_DIR_FILE..."
-    rm "$KA_LITE_SOURCE_DIR_FILE"
-else
-    echo "  Did not find $KA_LITE_SOURCE_DIR_FILE!"
-fi
-
-# Create a `ka-lite/kalite/local_settings.py`
-((STEP++))
-echo "$STEP/$STEPS. Creating '$LOCAL_SETTINGS_TARGET_PATH' from '$LOCAL_SETTINGS_DEFAULT_PATH'..."
-if [ -e "$LOCAL_SETTINGS_TARGET_PATH" ]; then
-    echo "  Found $LOCAL_SETTINGS_TARGET_PATH so will not overwrite it."
-else
-    cp "$LOCAL_SETTINGS_DEFAULT_PATH" "$LOCAL_SETTINGS_TARGET_PATH"
-fi
-
 # Install the `ka-lite-static` by running `pyrun setup.py install` inside the `ka-lite` directory.
 ((STEP++))
 echo "$STEP/$STEPS. Running '$PYRUN setup.py install .'... on '$KA_LITE_DIR'"
 KA_LITE_SETUP_PY="$KALITE_DIRsetup.py"
 cd "$KA_LITE_DIR"
 pwd
-$PYRUN setup.py install
+$PYRUN setup.py install --static
 if [ $? -ne 0 ]; then
     echo "  $0: Error/s encountered running '$PYRUN setup.py install', exiting..."
     exit 1
 fi
 cd "$WORKING_DIR/.."
 
-# exit 10
-
 # Run PyRun's pip install for `requirements.txt`
 ((STEP++))
 echo "$STEP/$STEPS. Running '$PYRUN_PIP install -r requirements.txt'... on '$KA_LITE_DIR' "
 $PYRUN_PIP install -r "$KA_LITE_DIR/requirements.txt"
 if [ $? -ne 0 ]; then
-    echo "  $0: Error/s encountered running '$PYRUN_PIP -install -r requirements.txt', exiting..."
+    echo "  $0: Error/s encountered running '$PYRUN_PIP install -r requirements.txt', exiting..."
     exit 1
 fi
 
@@ -208,20 +181,12 @@ if ! [ -d "$KA_LITE_MONITOR_RESOURCES_DIR" ]; then
 fi
 
 # Delete and re-create the destination folders to make sure we don't leave orphaned files.
-echo "  Checking $KA_LITE_MONITOR_RESOURCES_KA_LITE_DIR..."
-if [ -d "$KA_LITE_MONITOR_RESOURCES_KA_LITE_DIR" ]; then
-    echo "    Deleting $KA_LITE_MONITOR_RESOURCES_KA_LITE_DIR..."
-    rm -rf "$KA_LITE_MONITOR_RESOURCES_KA_LITE_DIR"
-fi
 echo "  Checking $KA_LITE_MONITOR_RESOURCES_PYRUN_DIR..."
 if [ -d "$KA_LITE_MONITOR_RESOURCES_PYRUN_DIR" ]; then
     echo "    Deleting $KA_LITE_MONITOR_RESOURCES_PYRUN_DIR..."
     rm -rf "$KA_LITE_MONITOR_RESOURCES_PYRUN_DIR"
 fi
 
-# Copy ka-lite...
-echo "  cp $KA_LITE_DIR $KA_LITE_MONITOR_RESOURCES_DIR"
-cp -R "$KA_LITE_DIR" "$KA_LITE_MONITOR_RESOURCES_DIR"
 # Copy pyrun...
 echo "  cp $PYRUN_DIR $KA_LITE_MONITOR_RESOURCES_DIR"
 cp -R "$PYRUN_DIR" "$KA_LITE_MONITOR_RESOURCES_DIR"

--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -70,10 +70,12 @@ PYRUN_DIR="$WORKING_DIR/pyrun-2.7"
 PYRUN="$PYRUN_DIR/bin/pyrun"
 PYRUN_PIP="$PYRUN_DIR/bin/pip"
 
+GITHUB_ACCOUNT="learningequality"
+
 KA_LITE="ka-lite"
 KA_LITE_ZIP="$WORKING_DIR/$KA_LITE.zip"
 KA_LITE_DIR="$WORKING_DIR/$KA_LITE"
-KA_LITE_REPO_ZIP="https://github.com/learningequality/ka-lite/zipball/develop/"
+KA_LITE_REPO_ZIP="https://github.com/$GITHUB_ACCOUNT/ka-lite/zipball/develop/"
 KA_LITE_EXECUTABLE="$KA_LITE_MONITOR_RESOURCES_DIR/$KA_LITE/kalite/bin/kalite"
 
 LOCAL_SETTINGS_DEFAULT_PATH="$KA_LITE_MONITOR_DIR/local_settings.default"
@@ -137,13 +139,13 @@ else
 
     # Extract KA-Lite
     echo "  Extracting '$KA_LITE_ZIP'..."
-    tar -xf $KA_LITE_ZIP
+    tar -xf $KA_LITE_ZIP -C $WORKING_DIR
     if [ $? -ne 0 ]; then
         echo "  $0: Can't extract '$KA_LITE_ZIP', exiting..."
         exit 1
     fi
     # Rename the extracted folder.
-    mv learningequality* $KA_LITE_DIR
+    mv $WORKING_DIR/$GITHUB_ACCOUNT* $KA_LITE_DIR
 fi
 
 # Create a `ka-lite/kalite/local_settings.py`


### PR DESCRIPTION
Hi @aronasorman - this PR:
* fixes #26 - Deploy ka-lite data folders to another location outside of the .app.
* fixes #91 - There's a bug that always shows the user preferences dialog.
* fixes #49 - MAC installer should use setup.py

**Must**

1. Please review and merge https://github.com/learningequality/ka-lite/pull/4115 first because this PR depends on the fixes there.

2. The `setup.sh` still points to the above learningequality/ka-lite#4115 PR for our tests, we will update it as soon as the above is merged.

**Updates**

1. Fixed the issue with video downloads, language downloads (etc - anything that calls `subprocess.Popen`) with PyRun.

2. Symlink `/Applications/KA-Lite Monitor.app/Contents/Resources/pyrun-2.7/bin/kalite` to `/usr/bin/kalite` so it can be accessed anywhere in the Terminal.  Previously we used `/usr/local/bin/kalite` which is the cause why video downloads don't work under Xcode but works when server is started on Terminal.

3. We disable the "Start KA Lite" menu if the `/usr/bin/kalite` is not found to prevent "unwanted side-effects" like errors that are not shown.  User must click the `Apply` button to make the `/usr/bin/symlink` before the "Start KA Lite" menu is enabled again.

4. We now default the database, user contents, assessment items, etc at `~/.kalite/` in reference to the `settings.USER_DATA_ROOT`.

5. We now use `ka-lite/setup.py` during build and exclude the `ka-lite` source from the .dmg built.  We have also removed the `ka-lite` from the Resources folder of the Xcode project.

6. We now have a complete "Reset App" button on the Advanced tab, which is useful to simulate a "clean" environment like prior to setup:
![screenshot 2015-07-22 17 26 49](https://cloud.githubusercontent.com/assets/175580/8822291/dd25642c-3096-11e5-821b-e1bfcc69cdc6.png)
