### PR TITLE
Hotfix/135 shebang checker corrupts the kalite executable

### DIFF
--- a/osx/KA-Lite-Monitor/KA-Lite-Monitor/scripts/shebangcheck.py
+++ b/osx/KA-Lite-Monitor/KA-Lite-Monitor/scripts/shebangcheck.py
@@ -62,6 +62,8 @@ for root, dirs, files in os.walk(BIN_PATH):
                             print "====> DON'T TOUCH!"
                         f.seek(0)
                         f.writelines(lines)
+                        # MUST: Important if the string to replace is longer than the one replacement.
+                        f.truncate()
         except Exception as exc:
             print "==> EXCEPTION: %s" % exc
             exit(1)

--- a/osx/KA-Lite-Monitor/KA-Lite-Monitor/scripts/shebangcheck.py
+++ b/osx/KA-Lite-Monitor/KA-Lite-Monitor/scripts/shebangcheck.py
@@ -62,7 +62,7 @@ for root, dirs, files in os.walk(BIN_PATH):
                             print "====> DON'T TOUCH!"
                         f.seek(0)
                         f.writelines(lines)
-                        # MUST: Important if the string to replace is longer than the one replacement.
+                        # MUST: Truncate if the string to replace is longer than the replacement.
                         f.truncate()
         except Exception as exc:
             print "==> EXCEPTION: %s" % exc


### PR DESCRIPTION
Hi @aronasorman - this fixes #135 - Shebang checker corrupts the kalite executable.

As commented on the issue: 

> The reason for this is that the new string to replace for the shebang line is shorter than the replacement, thus the "remaining" file contents persists.

We added `f.truncate()` to truncate the remaining file contents.