### PR TITLE
Enable KA-Lite documentation link  for mac installer

### DIFF
--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -250,7 +250,7 @@ $PYRUN_PIP install -r "$KA_LITE_DIR/requirements_sphinx.txt"
 cd $KA_LITE_DIR
 if [ -d "$KA_LITE_DIR" ]; then
     echo "Install npm.."
-    if ! command -v npm install > /dev/null; then
+    if ! command -v npm > /dev/null; then
         echo "Abort npm is not installed."
         exit 1
     else

--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -67,6 +67,9 @@ KA_LITE_LOGO_PATH="$SETUP_FILES_DIR/ka-lite-logo-full.png"
 KA_LITE_ICNS_PATH="$KA_LITE_MONITOR_DIR/Resources/images/ka-lite.icns"
 KA_LITE_README_PATH="$SETUP_FILES_DIR/README.md"
 
+PYRUN_SPHINX_BUILD="$PYRUN_DIR/bin/sphinx-build"
+KA_LITE_DOCS_DIR="$KA_LITE_DIR/docs"
+
 INSTALL_PYRUN="$WORKING_DIR/install-pyrun.sh"
 PYRUN_NAME="pyrun-2.7"
 PYRUN_DIR="$WORKING_DIR/$PYRUN_NAME"
@@ -238,6 +241,27 @@ $PYRUN_PIP install -r "$KA_LITE_DIR/requirements.txt"
 if [ $? -ne 0 ]; then
     echo "  $0: Error/s encountered running '$PYRUN_PIP install -r requirements.txt', exiting..."
     exit 1
+fi
+
+# Install requirements for sphinx
+# Reference ulimit: https://github.com/substack/node-browserify/issues/431
+echo "$STEP/$STEPS. Running npm install... on '$KA_LITE_DIR' "
+$PYRUN_PIP install -r "$KA_LITE_DIR/requirements_sphinx.txt"
+cd $KA_LITE_DIR
+if [ -d "$KA_LITE_DIR" ]; then
+    echo "Install npm.."
+    if ! command -v npm install > /dev/null; then
+        echo "Abort npm is not installed."
+        exit 1
+    else
+        npm install
+        ulimit -n 2560
+        node build.js
+        cd $KA_LITE_DIR/docs
+        $PYRUN_SPHINX_BUILD -b html -d _build/doctrees   . _build/html
+        cp -R -v $KA_LITE_DOCS_DIR $PYRUN_DIR/share/kalite
+    fi
+
 fi
 
 # Run `bin/kalite manage compileymltojson` by install pyyaml==3.11 then uninstall it afterwards


### PR DESCRIPTION
Hi @aronasorman this fixes #150 

I was able to modify the `setup.sh` for sphinx build and node installation for `pyrun`. This will enable the `Documentation` link in the Navbar

See the image below as demonstration 
![screenshot 2015-09-03 20 27 36](https://cloud.githubusercontent.com/assets/4099119/9658209/4761ffa8-527a-11e5-8bb5-3b0eb09908e2.png)