### PR TITLE
Update comments and steps

### DIFF
--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -4,17 +4,16 @@
 #
 # Steps
 # 1. Create temporary directory
-# 2. Download the `install-pyrun` script
-# 3. Download PyRun thru `install-pyrun` script.
-# 4. Download KA-Lite zip based on develop branch.
-# 5. Extract KA-Lite and move into `ka-lite` folder.
-# 6. Make ka-lite repo production-ready (delete .KALITE_SOURCE_DIR, etc).
+# 2. Download the assessment.zip and copy `assessment.zip` to the Xcode Resources folder.
+# 3. Download the `install-pyrun` script
+# 4. Download PyRun thru `install-pyrun` script.
+# 5. Download KA-Lite zip based on develop branch.
+# 6. Extract KA-Lite and move into `ka-lite` folder.
 # 7. Run pyrun-2.7/bin/pip install -r ka-lite/requirements.txt
 # 8. Run `bin/kalite manage compileymltojson`, needs `pyrun/pip install pyyaml==3.11`
-# 9. Create the `<Xcode_Resources>/ka-lite/kalite/local_settings.py` based on `local_settings.default`.
-# 10. Copy the `ka-lite` and `pyrun` folders to the Xcode Resources folder.
-# 11. Build the Xcode project to produce the .app.
-# 12. Build the .dmg.
+# 9. Copy `pyrun` folders to the Xcode Resources folder.
+# 10. Build the Xcode project to produce the .app.
+# 11. Build the .dmg.
 #
 # TODO(cpauya):
 # * use `tempfile.py` instead of `mktemp` which is "subject to race conditions"

--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -10,10 +10,10 @@
 # 5. Download KA-Lite zip based on develop branch and extract KA-Lite and move into `ka-lite` folder.
 # 6. Install the `ka-lite-static` by running `pyrun setup.py install` inside the `ka-lite` directory.
 # 7. Run pyrun-2.7/bin/pip install -r ka-lite/requirements.txt
-# 8. Install requirements for sphinx
+# 8. Building the docs using sphinx-build.
 # 9. Run `bin/kalite manage compileymltojson`, needs `pyrun/pip install pyyaml==3.11`
 # 10. Uninstall pyyaml so it's not included in the .dmg to build
-# 11. Copy `pyrun` folders to the Xcode Resources folder.
+# 11. Copy `pyrun` folder to the Xcode Resources folder.
 # 12. Build the Xcode project to produce the .app.
 # 13. Build the .dmg.
 #
@@ -53,7 +53,6 @@ SCRIPTPATH=`pwd`
 popd > /dev/null
 
 # Create temporary directory
-((STEP++))
 WORKING_DIR="$SCRIPTPATH/temp"
 if ! [ -d "$WORKING_DIR" ]; then
     echo "$STEP/$STEPS. Creating temporary directory..."
@@ -246,7 +245,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# Install requirements for sphinx
+# Building the docs using sphinx-build.
 # Reference ulimit: https://github.com/substack/node-browserify/issues/431
 ((STEP++))
 echo "$STEP/$STEPS. Running npm install... on '$KA_LITE_DIR' "

--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -253,12 +253,12 @@ $PYRUN_PIP install -r "$KA_LITE_DIR/requirements_sphinx.txt"
 cd $KA_LITE_DIR
 if [ -d "$KA_LITE_DIR" ]; then
     echo "Install npm.."
-        npm install
-        ulimit -n 2560
-        node build.js
-        cd $KA_LITE_DIR/docs
-        $PYRUN_SPHINX_BUILD -b html -d _build/doctrees   . _build/html
-        cp -R -v $KA_LITE_DOCS_DIR $PYRUN_DIR/share/kalite
+    npm install
+    ulimit -n 2560
+    node build.js
+    cd $KA_LITE_DIR/docs
+    $PYRUN_SPHINX_BUILD -b html -d _build/doctrees   . _build/html
+    cp -R -v $KA_LITE_DOCS_DIR $PYRUN_DIR/share/kalite
 
 fi
 

--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -7,13 +7,15 @@
 # 2. Download the assessment.zip and copy `assessment.zip` to the Xcode Resources folder.
 # 3. Download the `install-pyrun` script
 # 4. Download PyRun thru `install-pyrun` script.
-# 5. Download KA-Lite zip based on develop branch.
-# 6. Extract KA-Lite and move into `ka-lite` folder.
+# 5. Download KA-Lite zip based on develop branch and extract KA-Lite and move into `ka-lite` folder.
+# 6. Install the `ka-lite-static` by running `pyrun setup.py install` inside the `ka-lite` directory.
 # 7. Run pyrun-2.7/bin/pip install -r ka-lite/requirements.txt
-# 8. Run `bin/kalite manage compileymltojson`, needs `pyrun/pip install pyyaml==3.11`
-# 9. Copy `pyrun` folders to the Xcode Resources folder.
-# 10. Build the Xcode project to produce the .app.
-# 11. Build the .dmg.
+# 8. Install requirements for sphinx
+# 9. Run `bin/kalite manage compileymltojson`, needs `pyrun/pip install pyyaml==3.11`
+# 10. Uninstall pyyaml so it's not included in the .dmg to build
+# 11. Copy `pyrun` folders to the Xcode Resources folder.
+# 12. Build the Xcode project to produce the .app.
+# 13. Build the .dmg.
 #
 # TODO(cpauya):
 # * use `tempfile.py` instead of `mktemp` which is "subject to race conditions"
@@ -29,7 +31,7 @@ if [ -z ${TMPDIR+0} ]; then
 fi
 
 STEP=1
-STEPS=12
+STEPS=13
 
 # TODO(cpauya): This works but the problem is it creates the temporary directory everytime
 # script is run... so during devt, we will comment this for now.
@@ -50,6 +52,8 @@ pushd `dirname $0` > /dev/null
 SCRIPTPATH=`pwd`
 popd > /dev/null
 
+# Create temporary directory
+((STEP++))
 WORKING_DIR="$SCRIPTPATH/temp"
 if ! [ -d "$WORKING_DIR" ]; then
     echo "$STEP/$STEPS. Creating temporary directory..."
@@ -244,6 +248,7 @@ fi
 
 # Install requirements for sphinx
 # Reference ulimit: https://github.com/substack/node-browserify/issues/431
+((STEP++))
 echo "$STEP/$STEPS. Running npm install... on '$KA_LITE_DIR' "
 $PYRUN_PIP install -r "$KA_LITE_DIR/requirements_sphinx.txt"
 cd $KA_LITE_DIR
@@ -260,6 +265,7 @@ fi
 
 # Run `bin/kalite manage compileymltojson` by install pyyaml==3.11 then uninstall it afterwards
 # a. Run PyRun's pip install pyyaml==3.11
+((STEP++))
 echo "$STEP/$STEPS. Running '$PYRUN_PIP install pyyaml==3.11'... on '$KA_LITE_DIR' "
 $PYRUN_PIP install pyyaml==3.11
 if [ $? -ne 0 ]; then

--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -256,7 +256,7 @@ if [ -d "$KA_LITE_DIR" ]; then
     npm install
     ulimit -n 2560
     node build.js
-    cd $KA_LITE_DIR/docs
+    cd $KA_LITE_DOCS_DIR
     $PYRUN_SPHINX_BUILD -b html -d _build/doctrees   . _build/html
     cp -R -v $KA_LITE_DOCS_DIR $PYRUN_DIR/share/kalite
 


### PR DESCRIPTION
Hi @cpauya and @aronasorman  this fixes #161 

**Steps updated and removed:**
>1. Include the steps to download the assessment.zip and copy it to `Xcode Resources` folder.
>1. Will not include the `ka-lite` folder to copy in the Xcode Resources folder
>1. Remove step on creating the `local_settings.py` based on `local_settings.default`.
>1. Remove this step " `Make ka-lite repo production-ready (delete .KALITE_SOURCE_DIR, etc).".
 it is not necessary anymore. 
>1. Add this step "Uninstall pyyaml so it's not included in the .dmg to build."