### PR TITLE
Force restart after install

### DIFF
--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -29,6 +29,7 @@ SolidCompression=yes
 PrivilegesRequired=admin
 UsePreviousAppDir=yes
 ChangesEnvironment=yes
+AlwaysRestart=yes
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"


### PR DESCRIPTION
Fixes #123. Turned out to be really simple. Forces a restart after installation. Does not give the option of starting the app immediately.