### PR TITLE
Hotfix/169 mac 0.15 dev assets are not compiled

### DIFF
--- a/osx/KA-Lite-Monitor/KA-Lite-Monitor/AppDelegate.m
+++ b/osx/KA-Lite-Monitor/KA-Lite-Monitor/AppDelegate.m
@@ -965,7 +965,7 @@ BOOL setEnvVars(BOOL createPlist) {
     // Automatically run `kalite manage setup` if no database was found.
     NSString *databasePath = getDatabasePath();
     if (!pathExists(databasePath)) {
-        if (kaliteExists()) {
+        if (checkUsrBinKalitePath()) {
             alert(@"Will now run KA-Lite setup, it will take a few minutes.  Please wait until prompted that setup is done.");
             enum kaliteStatus status = [self setupKalite];
             showNotification(@"Setup is finished!  You can now start KA-Lite.");

--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -257,7 +257,7 @@ if [ -d "$KA_LITE_DIR" ]; then
     ulimit -n 2560
     node build.js
     if [ $? -ne 0 ]; then
-    echo "  $0: Error/s encountered running node build.js', exiting..."
+        echo "  $0: Error/s encountered running node build.js', exiting..."
         exit 1
     fi
     cd $KA_LITE_DOCS_DIR

--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -69,9 +69,6 @@ KA_LITE_LOGO_PATH="$SETUP_FILES_DIR/ka-lite-logo-full.png"
 KA_LITE_ICNS_PATH="$KA_LITE_MONITOR_DIR/Resources/images/ka-lite.icns"
 KA_LITE_README_PATH="$SETUP_FILES_DIR/README.md"
 
-PYRUN_SPHINX_BUILD="$PYRUN_DIR/bin/sphinx-build"
-KA_LITE_DOCS_DIR="$KA_LITE_DIR/docs"
-
 INSTALL_PYRUN="$WORKING_DIR/install-pyrun.sh"
 PYRUN_NAME="pyrun-2.7"
 PYRUN_DIR="$WORKING_DIR/$PYRUN_NAME"
@@ -245,6 +242,9 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+PYRUN_SPHINX_BUILD="$PYRUN_DIR/bin/sphinx-build"
+KA_LITE_DOCS_DIR="$KA_LITE_DIR/docs"
+
 # Building the docs using sphinx-build.
 # Reference ulimit: https://github.com/substack/node-browserify/issues/431
 ((STEP++))
@@ -256,6 +256,10 @@ if [ -d "$KA_LITE_DIR" ]; then
     npm install
     ulimit -n 2560
     node build.js
+    if [ $? -ne 0 ]; then
+    echo "  $0: Error/s encountered running node build.js', exiting..."
+        exit 1
+    fi
     cd $KA_LITE_DOCS_DIR
     $PYRUN_SPHINX_BUILD -b html -d _build/doctrees   . _build/html
     cp -R -v $KA_LITE_DOCS_DIR $PYRUN_DIR/share/kalite

--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -8,9 +8,9 @@
 # 3. Download the `install-pyrun` script
 # 4. Download PyRun thru `install-pyrun` script.
 # 5. Download KA-Lite zip based on develop branch and extract KA-Lite and move into `ka-lite` folder.
-# 7. Run pyrun-2.7/bin/pip install -r ka-lite/requirements.txt
-# 8. Building the docs using sphinx-build.
-# 6. Install the `ka-lite-static` by running `pyrun setup.py install` inside the `ka-lite` directory.
+# 6. Run pyrun-2.7/bin/pip install -r ka-lite/requirements.txt
+# 7. Install the `ka-lite-static` by running `pyrun setup.py install` inside the `ka-lite` directory.
+# 8. Building the docs using sphinx-build. 
 # 9. Run `bin/kalite manage compileymltojson`, needs `pyrun/pip install pyyaml==3.11`
 # 10. Uninstall pyyaml so it's not included in the .dmg to build
 # 11. Copy `pyrun` folder to the Xcode Resources folder.
@@ -230,13 +230,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-PYRUN_SPHINX_BUILD="$PYRUN_DIR/bin/sphinx-build"
-KA_LITE_DOCS_DIR="$KA_LITE_DIR/docs"
 
-# Building the docs using sphinx-build.
-# Reference ulimit: https://github.com/substack/node-browserify/issues/431
-((STEP++))
-echo "$STEP/$STEPS. Running npm install... on '$KA_LITE_DIR' "
 $PYRUN_PIP install -r "$KA_LITE_DIR/requirements_sphinx.txt"
 cd $KA_LITE_DIR
 echo "Install npm.."
@@ -248,13 +242,6 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-cd $KA_LITE_DOCS_DIR
-$PYRUN_SPHINX_BUILD -b html -d _build/doctrees . _build/html
-if [ $? -ne 0 ]; then
-    echo "  $0: Error/s encountered running sphinx-build', exiting..."
-    exit 1
-fi
-cp -R -v $KA_LITE_DOCS_DIR $PYRUN_DIR/share/kalite
 
 # Install the `ka-lite-static` by running `pyrun setup.py install` inside the `ka-lite` directory.
 ((STEP++))
@@ -275,6 +262,21 @@ if [ "$FIND_RESULT" == "" ]; then
     echo "No bundle*.js files found in $PYRUN_DIR, will exit."
     exit 1
 fi
+
+PYRUN_SPHINX_BUILD="$PYRUN_DIR/bin/sphinx-build"
+KA_LITE_DOCS_DIR="$KA_LITE_DIR/docs"
+
+# Building the docs using sphinx-build.
+# Reference ulimit: https://github.com/substack/node-browserify/issues/431
+((STEP++))
+echo "$STEP/$STEPS. Running sphinx-build ... on '$KA_LITE_DIR' "
+cd $KA_LITE_DOCS_DIR
+$PYRUN_SPHINX_BUILD -b html -d _build/doctrees . _build/html
+if [ $? -ne 0 ]; then
+    echo "  $0: Error/s encountered running sphinx-build', exiting..."
+    exit 1
+fi
+cp -R -v $KA_LITE_DOCS_DIR $PYRUN_DIR/share/kalite
 
 # Run `bin/kalite manage compileymltojson` by install pyyaml==3.11 then uninstall it afterwards
 # a. Run PyRun's pip install pyyaml==3.11

--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -145,12 +145,12 @@ fi
 
 if [ -f "$KA_LITE_MONITOR_RESOURCES_DIR/$ASSESSMENT_ZIP" ]; then
     rm -rf "$KA_LITE_MONITOR_RESOURCES_DIR/$ASSESSMENT_ZIP"
-    echo "delete assessment zip at $KA_LITE_MONITOR_RESOURCES_DIR/$ASSESSMENT_ZIP"
+    echo "  Deleting target assessment zip (to be overwritten below) at $KA_LITE_MONITOR_RESOURCES_DIR/$ASSESSMENT_ZIP"
 fi
 
 if [ -f "$ASSESSMENT_PATH" ]; then
     # Copy assessment
-    echo "cp $ASSESSMENT_PATH $KA_LITE_MONITOR_RESOURCES_DIR"
+    echo "  Copying new $ASSESSMENT_PATH to $KA_LITE_MONITOR_RESOURCES_DIR"
     cp -R "$ASSESSMENT_PATH" "$KA_LITE_MONITOR_RESOURCES_DIR"
 fi
 
@@ -259,6 +259,16 @@ if [ $? -ne 0 ]; then
     echo "  $0: Error/s encountered running node build.js', exiting..."
     exit 1
 fi
+
+# MUST: double-check that there are bundled files
+cd "$PYRUN_DIR"
+echo "  Double-checking that there are bundle*.js files..."
+FIND_RESULT=`find . -name "bundle*.js"`
+if [ "$FIND_RESULT" == "" ]; then
+    echo "No bundle*.js files found, will exit."
+    exit 1
+fi
+
 cd $KA_LITE_DOCS_DIR
 $PYRUN_SPHINX_BUILD -b html -d _build/doctrees . _build/html
 if [ $? -ne 0 ]; then
@@ -266,13 +276,6 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 cp -R -v $KA_LITE_DOCS_DIR $PYRUN_DIR/share/kalite
-# MUST: double-check that there are bundled files
-cd "$PYRUN_DIR"
-find . -name "bundle*.js"
-if [ $? -ne 0 ]; then
-    echo "No bundle*.js files found, will exit!"
-    exit 1
-fi
 
 # Run `bin/kalite manage compileymltojson` by install pyyaml==3.11 then uninstall it afterwards
 # a. Run PyRun's pip install pyyaml==3.11

--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -251,19 +251,27 @@ KA_LITE_DOCS_DIR="$KA_LITE_DIR/docs"
 echo "$STEP/$STEPS. Running npm install... on '$KA_LITE_DIR' "
 $PYRUN_PIP install -r "$KA_LITE_DIR/requirements_sphinx.txt"
 cd $KA_LITE_DIR
-if [ -d "$KA_LITE_DIR" ]; then
-    echo "Install npm.."
-    npm install
-    ulimit -n 2560
-    node build.js
-    if [ $? -ne 0 ]; then
-        echo "  $0: Error/s encountered running node build.js', exiting..."
-        exit 1
-    fi
-    cd $KA_LITE_DOCS_DIR
-    $PYRUN_SPHINX_BUILD -b html -d _build/doctrees   . _build/html
-    cp -R -v $KA_LITE_DOCS_DIR $PYRUN_DIR/share/kalite
-
+echo "Install npm.."
+npm install
+ulimit -n 2560
+node build.js
+if [ $? -ne 0 ]; then
+    echo "  $0: Error/s encountered running node build.js', exiting..."
+    exit 1
+fi
+cd $KA_LITE_DOCS_DIR
+$PYRUN_SPHINX_BUILD -b html -d _build/doctrees . _build/html
+if [ $? -ne 0 ]; then
+    echo "  $0: Error/s encountered running sphinx-build', exiting..."
+    exit 1
+fi
+cp -R -v $KA_LITE_DOCS_DIR $PYRUN_DIR/share/kalite
+# MUST: double-check that there are bundled files
+cd "$PYRUN_DIR"
+find . -name "bundle*.js"
+if [ $? -ne 0 ]; then
+    echo "No bundle*.js files found, will exit!"
+    exit 1
 fi
 
 # Run `bin/kalite manage compileymltojson` by install pyyaml==3.11 then uninstall it afterwards


### PR DESCRIPTION
Hi @aronasorman - this fixes #169 "mac 0.15 dev assets are not compiled".

We moved the step to run `pyrun setup.py install` after running the `node build.js` so that the `bundle*.js` files are included when copied inside the `pyrun-2.7` directory.

`bundle*.js` files are now bundled in the KA-Lite-Monitor.app:

```bash
cyril-lappy6:~ cyril$ cd /Applications/KA-Lite-Monitor.app/
cyril-lappy6:KA-Lite-Monitor.app cyril$ find ./ -name "bundle*.js"
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/coachreports/static/js/coachreports/bundles/bundle_coach_report.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/coachreports/static/js/coachreports/bundles/bundle_student_progress.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/control_panel/static/js/control_panel/bundles/bundle_clock_set.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/control_panel/static/js/control_panel/bundles/bundle_data_export.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/control_panel/static/js/control_panel/bundles/bundle_facility_management.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/control_panel/static/js/control_panel/bundles/bundle_zone_management.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/distributed/static/js/distributed/bundles/bundle_audio.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/distributed/static/js/distributed/bundles/bundle_base.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/distributed/static/js/distributed/bundles/bundle_common.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/distributed/static/js/distributed/bundles/bundle_compatibility.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/distributed/static/js/distributed/bundles/bundle_document.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/distributed/static/js/distributed/bundles/bundle_exercise.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/distributed/static/js/distributed/bundles/bundle_homepage.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/distributed/static/js/distributed/bundles/bundle_learn.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/distributed/static/js/distributed/bundles/bundle_register_public_key_client.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/distributed/static/js/distributed/bundles/bundle_video.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/inline/static/js/inline/bundles/bundle_inline_help.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/updates/static/js/updates/bundles/bundle_update_languages.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/updates/static/js/updates/bundles/bundle_update_software.js
.//Contents/Resources/pyrun-2.7/lib/python2.7/site-packages/ka_lite-0.15.0-py2.7.egg/kalite/updates/static/js/updates/bundles/bundle_update_videos.js
cyril-lappy6:KA-Lite-Monitor.app cyril$
```

Running site on http://127.0.0.1:8008/
![screenshot 2015-09-21 16 13 31](https://cloud.githubusercontent.com/assets/175580/9987600/d8e7c9ee-607b-11e5-8878-f2d9e238ccfc.png)
