### PR TITLE
Show output from setup command

### DIFF
--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -416,7 +416,7 @@ begin
     Exec(ExpandConstant('{cmd}'), '/S /C "xcopy "' + ExpandConstant('{app}') + '\ka-lite\kalite\database" "%USERPROFILE%\.kalite\database\" /E /Y"', '', SW_HIDE, ewWaitUntilTerminated, retCode);
     MsgBox('Setup will now configure the database. This operation may take a few minutes. Please be patient.', mbInformation, MB_OK);
     setupCommand := 'kalite manage setup --noinput --hostname="'+ServerInformationPage.Values[0]+'" --description="'+ServerInformationPage.Values[1]+'"';
-    if Not ShellExec('open', 'python.exe', setupCommand, ExpandConstant('{app}')+'\ka-lite\bin', SW_HIDE, ewWaitUntilTerminated, retCode) then
+    if Not ShellExec('open', 'python.exe', setupCommand, ExpandConstant('{app}')+'\ka-lite\bin', SW_SHOW, ewWaitUntilTerminated, retCode) then
     begin
         MsgBox('Critical error.' #13#13 'Setup has failed to initialize the database; aborting the install.', mbInformation, MB_OK);
         forceCancel := True;


### PR DESCRIPTION
Trying to debug https://github.com/learningequality/installers/issues/178.

@cpauya can you build an installer from this branch, and try it out to determine:

1. *If* the setup command is failing on ~~Windows 7 or lower~~ any version of Windows, as I suspect is happening in #178.
2. If it is failing, why?

For faster building/installing, don't bother to include assessment items, but *do* include documentation. I'm taking a crack at it myself, but given the slow build/install time it would be helpful to have many people trying it out on different windows versions simultaneously.