### PR TITLE
Remove setup mgmt command from installer

### DIFF
--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -413,15 +413,8 @@ var
     retCode: integer;
 begin
     { Copy the bundled empty db to the proper location. }
+    { Used to have more responsibility, but we delegated those to the app itself! }
     Exec(ExpandConstant('{cmd}'), '/S /C "xcopy "' + ExpandConstant('{app}') + '\ka-lite\kalite\database" "%USERPROFILE%\.kalite\database\" /E /Y"', '', SW_HIDE, ewWaitUntilTerminated, retCode);
-    MsgBox('Setup will now configure the database. This operation may take a few minutes. Please be patient.', mbInformation, MB_OK);
-    setupCommand := 'kalite manage setup --noinput --hostname="'+ServerInformationPage.Values[0]+'" --description="'+ServerInformationPage.Values[1]+'"';
-    if Not ShellExec('open', 'python.exe', setupCommand, ExpandConstant('{app}')+'\ka-lite\bin', SW_HIDE, ewWaitUntilTerminated, retCode) then
-    begin
-        MsgBox('Critical error.' #13#13 'Setup has failed to initialize the database; aborting the install.', mbInformation, MB_OK);
-        forceCancel := True;
-        WizardForm.Close;
-    end;
 end;
 
 procedure CurStepChanged(CurStep: TSetupStep);


### PR DESCRIPTION
Called the setup mgmt command, but apparently the KALITE_ROOT_DATA_PATH
  environment variable was not set properly -- the installer would have
  to exit first for the change to be broadcast.

Instead, let the app handle the setup the first time it's started.

Fixes #178. Implements the solution I described in https://github.com/learningequality/installers/pull/188#issuecomment-144225204. @cpauya can you review/test this out? But hold off on merging, for now.