### PR TITLE
Fix setup.sh to change default of second argument

### DIFF
--- a/osx/setup.sh
+++ b/osx/setup.sh
@@ -80,7 +80,7 @@ PYRUN_PIP="$PYRUN_DIR/bin/pip"
 ASSESSMENT_ZIP="assessment.zip"
 ASSESSMENT_PATH="$WORKING_DIR/$ASSESSMENT_ZIP"
 ASSESSMENT_KALITE_MONITOR="$KA_LITE_MONITOR_RESOURCES_DIR"
-ASSESSMENT_URL="https://learningequality.org/downloads/ka-lite/0.14/content/assessment.zip"
+ASSESSMENT_URL="https://learningequality.org/downloads/ka-lite/0.15/content/khan_assessment.zip"
 
 KA_LITE="ka-lite"
 KA_LITE_ZIP="$WORKING_DIR/$KA_LITE.zip"


### PR DESCRIPTION
@cpauya I changed the default assessment url of the `setup.sh` to `https://learningequality.org/downloads/ka-lite/0.15/content/khan_assessment.zip`. I attached the screenshot when running `setup.sh`. 
![screen shot 2015-10-13 at 7 05 43 pm](https://cloud.githubusercontent.com/assets/8663934/10453405/50f8acb4-71de-11e5-95f1-5ea7eec8645f.png)
