### PR TITLE
Upgrade process for OS X installer 0.16.0

### DIFF
--- a/osx/KA-Lite/KA-Lite/AppDelegate.m
+++ b/osx/KA-Lite/KA-Lite/AppDelegate.m
@@ -715,7 +715,7 @@ BOOL setEnvVars() {
     
     // Path of the KALITE_PYTHON environment variable
     NSString* envKalitePythonStr = getEnvVar(@"KALITE_PYTHON");
-    if (! pathExist(envKalitePythonStr)) {
+    if (! pathExists(envKalitePythonStr)) {
         return FALSE;
     }
     NSString *KaliteHomeStr = [NSString stringWithFormat:@"%@",

--- a/osx/build.sh
+++ b/osx/build.sh
@@ -284,6 +284,10 @@ if [ -d "$KA_LITE_PROJECT_DIR" ]; then
     # MUST: xcodebuild needs to be on the same directory as the .xcodeproj file
     cd "$KA_LITE_PROJECT_DIR"
     xcodebuild clean build
+    if [ $? -ne 0 ]; then
+        echo ".. Abort!  Running \"xcodebuild clean build\" failed!"
+        exit 1
+    fi
 fi
 # check if build of Xcode project succeeded
 KA_LITE_APP_PATH="$KA_LITE_PROJECT_DIR/build/Release/KA-Lite.app"

--- a/osx/pre_installation.sh
+++ b/osx/pre_installation.sh
@@ -15,9 +15,11 @@
 #----------------------------------------------------------------------
 # Global Variables
 #----------------------------------------------------------------------
+KALITE_MONITOR="/Applications/KA-Lite-Monitor.app"
 KALITE="kalite"
 KALITE_PLIST="org.learningequality.kalite.plist"
-LAUNCH_AGENTS="$HOME/Library/LaunchAgents"
+HOME_LAUNCH_AGENTS="$HOME/Library/LaunchAgents"
+ROOT_LAUNCH_AGENTS="/Library/LaunchAgents"
 LIBRARY_PLIST="$LAUNCH_AGENTS/$KALITE_PLIST"
 KALITE_EXECUTABLE_PATH="$(which $KALITE)"
 KALITE_RESOURCES="/Users/Shared/ka-lite"
@@ -35,14 +37,7 @@ function append() {
 
 
 function remove_files_initiator {
-    if [ -f $LIBRARY_PLIST ]; then
-        append REMOVE_FILES_ARRAY $LIBRARY_PLIST
-    fi
-
-    if [ -d "$KALITE_RESOURCES" ]; then
-        append REMOVE_FILES_ARRAY $KALITE_RESOURCES
-    fi
-
+   
     if which kalite > /dev/null 2>&1; then
         append REMOVE_FILES_ARRAY $KALITE_EXECUTABLE_PATH
     fi
@@ -91,6 +86,12 @@ function check_kalite_exc_collector {
 #----------------------------------------------------------------------
 ENV=$(env)
 syslog -s -l error "Packages pre-installation initialize with env:'\n'$ENV" 
+
+# Collect the directories and files to remove
+append REMOVE_FILES_ARRAY $HOME_LAUNCH_AGENTS/$KALITE_PLIST
+append REMOVE_FILES_ARRAY $ROOT_LAUNCH_AGENTS/$KALITE_PLIST
+append REMOVE_FILES_ARRAY $KALITE_RESOURCES
+append REMOVE_FILES_ARRAY $KALITE_MONITOR
 
 echo "Unset the KALITE_PYTHON environment variable"
 launchctl unsetenv KALITE_PYTHON


### PR DESCRIPTION
Hi @aronasorman, @cpauya and @djallado .
This fixes #282 

**Upgrade Checklist :**
- [x] Remove /Library/LaunchAgents/org.learningequality.kalite.plist.
- [x] Remove existing KA-Lite-Monitor.app in /Applications folder
- [x] Retain .kalite