### PR TITLE
Change Base SDK to Latest to make El Capitan run setup.sh.

### DIFF
--- a/osx/KA-Lite-Monitor/KA-Lite-Monitor.xcodeproj/project.pbxproj
+++ b/osx/KA-Lite-Monitor/KA-Lite-Monitor.xcodeproj/project.pbxproj
@@ -365,7 +365,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				PRODUCT_NAME = "KA-Lite-Monitor";
-				SDKROOT = macosx10.9;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -390,7 +390,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_NAME = "KA-Lite-Monitor";
-				SDKROOT = macosx10.9;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
@cpauya This a hotfix to make `El Capitan` run `setup.sh` without error.
**Screenshot:** running `setup.sh` in `El Capitan`.
![screen shot 2015-12-02 at 3 10 26 pm](https://cloud.githubusercontent.com/assets/8664071/11524697/e0d9ec44-9907-11e5-9613-cf43fc6ca6ef.png)
