### PR TITLE
Load assessment item before setup

### DIFF
--- a/osx/ka-lite-remover.sh
+++ b/osx/ka-lite-remover.sh
@@ -27,6 +27,7 @@ KALITE_RESOURCES="/Users/Shared/ka-lite"
 KALITE_USR_BIN_PATH="/usr/bin"
 KALITE_USR_LOCAL_BIN_PATH="/usr/local/bin"
 KALITE_UNINSTALL_SCRIPT="KA-Lite_Uninstall.tool"
+KALITE_PREFS_PLIST="$HOME_LAUNCH_AGENTS/org.learningequality.kalite.prefs.plist"
 
 REMOVE_FILES_ARRAY=()
 
@@ -93,11 +94,9 @@ popd > /dev/null
 test -d /Applications/KA-Lite                   && REMOVE_FILES_ARRAY+=("/Applications/KA-Lite")
 test -f $SCRIPTPATH/$KALITE_UNINSTALL_SCRIPT    && REMOVE_FILES_ARRAY+=("$SCRIPTPATH/$KALITE_UNINSTALL_SCRIPT")
 test -d $KALITE_RESOURCES                       && REMOVE_FILES_ARRAY+=("$KALITE_RESOURCES")
-test -f $HOME_LAUNCH_AGENTS/$KALITE_PLIST       && REMOVE_FILES_ARRAY+=("$HOME_LAUNCH_AGENTS/$KALITE_PLIST")
-test -f $ROOT_LAUNCH_AGENTS/$KALITE_PLIST       && REMOVE_FILES_ARRAY+=("$ROOT_LAUNCH_AGENTS/$KALITE_PLIST")
 test -f $KALITE_USR_LOCAL_BIN_PATH/$KALITE      && REMOVE_FILES_ARRAY+=("$KALITE_USR_LOCAL_BIN_PATH/$KALITE")
 test -f $KALITE_USR_BIN_PATH/$KALITE            && REMOVE_FILES_ARRAY+=("$KALITE_USR_BIN_PATH/$KALITE")
-test -f $KALITE_MONITOR_APP                     && REMOVE_FILES_ARRAY+=("$KALITE_MONITOR_APP")
+test -d $KALITE_MONITOR                         && REMOVE_FILES_ARRAY+=("$KALITE_MONITOR")
 
 if [ "$SCRIPT_NAME" != "preinstall" ]; then
     # Introduction 
@@ -116,6 +115,13 @@ if [ "$SCRIPT_NAME" != "preinstall" ]; then
 
 fi
 
+for root_plist in $ROOT_LAUNCH_AGENTS/org.learningequality.*.plist; do
+    append REMOVE_FILES_ARRAY $root_plist
+done
+
+for home_plist in $HOME_LAUNCH_AGENTS/org.learningequality.*.plist; do
+    append REMOVE_FILES_ARRAY $home_plist
+done
 
 # Print the files and directories that are to be removed and verify
 # with the user that that is what he/she really wants to do.

--- a/osx/ka-lite-remover.sh
+++ b/osx/ka-lite-remover.sh
@@ -27,7 +27,6 @@ KALITE_RESOURCES="/Users/Shared/ka-lite"
 KALITE_USR_BIN_PATH="/usr/bin"
 KALITE_USR_LOCAL_BIN_PATH="/usr/local/bin"
 KALITE_UNINSTALL_SCRIPT="KA-Lite_Uninstall.tool"
-KALITE_PREFS_PLIST="$HOME_LAUNCH_AGENTS/org.learningequality.kalite.prefs.plist"
 
 REMOVE_FILES_ARRAY=()
 

--- a/osx/post_installation.sh
+++ b/osx/post_installation.sh
@@ -13,8 +13,8 @@
 # 4. Run shebangcheck that check the BIN_PATH that points to the python/pyrun interpreter to use.
 # 5. Run kalite manage syncdb --noinput.
 # 6. Run kalite manage init_content_items --overwrite.
-# 7. Run kalite manage setup --noinput.
-# 8. Run kalite manage unpack_assessment_zip <assessment_path>.
+# 7. Run kalite manage unpack_assessment_zip <assessment_path>.
+# 8. Run kalite manage setup --noinput..
 # 9. Change the owner of the ~/.kalite/ folder.
 # 10. Create a copy of ka-lite-remover.sh and name it as KA-Lite_Uninstall.tool.
 
@@ -182,13 +182,13 @@ $BIN_PATH/kalite manage init_content_items --overwrite
 
 
 ((STEP++))
-echo "$STEP/$STEPS. Running kalite manage setup --noinput..."
-$BIN_PATH/kalite manage setup --noinput
+echo "$STEP/$STEPS. Running kalite manage unpack_assessment_zip '$ASSESSMENT_SRC'..."
+$BIN_PATH/kalite manage unpack_assessment_zip $ASSESSMENT_SRC    
 
 
 ((STEP++))
-echo "$STEP/$STEPS. Running kalite manage unpack_assessment_zip '$ASSESSMENT_SRC'..."
-$BIN_PATH/kalite manage unpack_assessment_zip $ASSESSMENT_SRC    
+echo "$STEP/$STEPS. Running kalite manage setup --noinput..."
+$BIN_PATH/kalite manage setup --noinput
 
 
 ((STEP++))


### PR DESCRIPTION
Hi @cpauya, @aronasorman and @djallado  this fixes #308

**This fix include the following:**
> Remove `org.learningequality.*.plist` file in the root and home directory.
> Load assessment item before issue `kalite manage setup --noinput`

See attach screen shot for demo.
![screen shot 2015-12-09 at 2 34 10 pm](https://cloud.githubusercontent.com/assets/4099119/11678347/fb91b2ea-9e81-11e5-872e-3cd1346d5412.png)
