### PR TITLE
Bamboo make script for Windows installer

### DIFF
--- a/windows/make_dist.sh
+++ b/windows/make_dist.sh
@@ -1,0 +1,12 @@
+pushd ka-lite
+
+/usr/local/bin/virtualenv venv
+source venv/bin/activate
+pip install -r requirements_dev.txt
+pip install -r requirements_sphinx.txt
+/usr/bin/make dist
+rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
+deactivate
+rm -r venv
+
+popd


### PR DESCRIPTION
Goes hand in hand with https://github.com/learningequality/ka-lite/pull/4762. Used to be an inline script on the build server, but I was reduced to trying different things one-by-one to see what breaks the build and what doesn't. Doesn't seem to have made a difference... ?

Don't merge, opened to keep track.