### PR TITLE
Add systemstart task scripts to installer repo, fix bug

### DIFF
--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -444,7 +444,7 @@ begin
       
             if StartupPage.SelectedValueIndex = 0 then
             begin
-                if ShellExec('open','guitools.vbs','4', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, StartupCode) then
+                if Exec(ExpandConstant('{cmd}'), '/C "schtasks /create /tn "KALite" /tr "\"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat\" start" /sc onstart /ru SYSTEM"', '', SW_HIDE, ewWaitUntilTerminated, StartupCode) then
                 begin
                     if Not SaveStringToFile(ExpandConstant('{app}')+'\CONFIG.dat', 'RUN_AT_STARTUP:TRUE;' + #13#10, False) then
                     begin

--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -39,7 +39,7 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 [Files]
 Source: "..\ka-lite\dist\ka-lite-static-*.zip"; DestDir: "{app}\ka-lite"
 Source: "..\khan_assessment.zip"; DestDir: "{app}"
-Source: "..\ka-lite\scripts\*.bat"; DestDir: "{app}\ka-lite\scripts\"
+Source: "..\scripts\*.bat"; DestDir: "{app}\ka-lite\scripts\"
 Source: "..\gui-packed\KA Lite.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\gui-packed\guitools.vbs"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\gui-packed\images\logo48.ico"; DestDir: "{app}\images"; Flags: ignoreversion

--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -444,7 +444,7 @@ begin
       
             if StartupPage.SelectedValueIndex = 0 then
             begin
-                if Exec(ExpandConstant('{cmd}'), '/C "schtasks /create /tn "KALite" /tr "\"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat\" start" /sc onstart /ru SYSTEM"', '', SW_HIDE, ewWaitUntilTerminated, StartupCode) then
+                if Exec(ExpandConstant('{cmd}'), ExpandConstant('/C "schtasks /create /tn "KALite" /tr "\"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat\" start" /sc onstart /ru SYSTEM"'), '', SW_HIDE, ewWaitUntilTerminated, StartupCode) then
                 begin
                     if Not SaveStringToFile(ExpandConstant('{app}')+'\CONFIG.dat', 'RUN_AT_STARTUP:TRUE;' + #13#10, False) then
                     begin

--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -451,7 +451,7 @@ begin
                 { Windows 5.1 is XP, and 5.2 is Server 2003/64-bit XP. See https://msdn.microsoft.com/en-us/library/windows/desktop/ms724832(v=vs.85).aspx }
                 if (windowsVersion.Major = 5) and (windowsVersion.Minor <= 2) then
                 begin
-                    kaliteSchtaskCmd := ExpandConstant('/C "schtasks /create /tn "KALite" /tr "\"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat\" start" /sc onstart"');
+                    MsgBox('Start at boot option is unavailable on this version of Windows.' #13#13 'The installation will now proceed.', mbError, MB_OK);
                 end
                 else begin
                     kaliteSchtaskCmd := ExpandConstant('/C "schtasks /create /tn "KALite" /tr "\"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat\" start" /sc onstart /ru SYSTEM"');

--- a/windows/scripts/add_systemstart_task.bat
+++ b/windows/scripts/add_systemstart_task.bat
@@ -1,3 +1,13 @@
 @echo off
 TITLE Adding task to start KA Lite at system start
-schtasks /create /tn "KALite" /tr "\"%KALITE_SCRIPT_DIR%\kalite.bat\" start" /sc onstart /ru SYSTEM /f
+
+setlocal
+for /f "tokens=4-6 delims=[.XP " %%i in ('ver') do set WIN_VERSION="%%i.%%j"
+
+rem 5.1 and 5.2 are XP and Server 2003/64-bit XP
+if %WIN_VERSION% LEQ "5.2" (
+    echo This feature is unavailable on this version of Windows.
+    pause
+) else (
+    schtasks /create /tn "KALite" /tr "\"%KALITE_SCRIPT_DIR%\kalite.bat\" start" /sc onstart /ru SYSTEM /f
+)

--- a/windows/scripts/add_systemstart_task.bat
+++ b/windows/scripts/add_systemstart_task.bat
@@ -1,0 +1,3 @@
+@echo off
+TITLE Adding task to start KA Lite at system start
+schtasks /create /tn "KALite" /tr "\"%KALITE_SCRIPT_DIR%\kalite.bat\" start" /sc onstart /ru SYSTEM

--- a/windows/scripts/add_systemstart_task.bat
+++ b/windows/scripts/add_systemstart_task.bat
@@ -1,3 +1,3 @@
 @echo off
 TITLE Adding task to start KA Lite at system start
-schtasks /create /tn "KALite" /tr "\"%KALITE_SCRIPT_DIR%\kalite.bat\" start" /sc onstart /ru SYSTEM
+schtasks /create /tn "KALite" /tr "\"%KALITE_SCRIPT_DIR%\kalite.bat\" start" /sc onstart /ru SYSTEM /f

--- a/windows/scripts/remove_systemstart_task.bat
+++ b/windows/scripts/remove_systemstart_task.bat
@@ -1,0 +1,3 @@
+@echo off
+TITLE Removing task to start KA Lite at system start
+schtasks /delete /tn "KALite" /ru SYSTEM

--- a/windows/scripts/remove_systemstart_task.bat
+++ b/windows/scripts/remove_systemstart_task.bat
@@ -1,3 +1,3 @@
 @echo off
 TITLE Removing task to start KA Lite at system start
-schtasks /delete /tn "KALite" /ru SYSTEM
+schtasks /delete /tn "KALite"


### PR DESCRIPTION
Fixes #106 -- should start at boot now.
These scripts are updated, and should be removed from the ka-lite repo... they do no good there!

commitmsg
```
Copy them, and instead of referencing the now defunct bin/windows/kalite.bat
script, use the included kalite.bat script in the ..\Python27\Scripts\ dir.
```