### PR TITLE
[Windows] Change CONFIG.dat file location, behavior

### DIFF
--- a/windows/gui-source/KA Lite/config.h
+++ b/windows/gui-source/KA Lite/config.h
@@ -289,7 +289,6 @@ int addValue(const char* const configurationBuffer, const char* const targetKey,
 	if(key_size == 0 || value_size == 0) return 1;
 
 	int keyIndex = 0;
-	char * writeBuffer = (char*)malloc(sizeof(char) * FILE_BUFFER_SIZE);
 	keyIndex = searchKeyIndex(configurationBuffer, targetKey);
 
 	int tempIndex = 0;

--- a/windows/gui-source/KA Lite/config.h
+++ b/windows/gui-source/KA Lite/config.h
@@ -18,6 +18,7 @@ int joinPath(LPCTSTR const path1, LPCTSTR const path2, LPTSTR const& resultBuffe
 int getConfigFilePath(LPTSTR const& resultBuffer, const UINT resBuffLen);
 
 
+
 /*
 *	Read the configuration file to some buffer.
 *	:param char* const& resultConfigurationBuffer: The buffer into which the configuration file is read.
@@ -43,7 +44,7 @@ int readConfigurationFileBuffer(char* const& resultConfigurationBuffer)
 
 	if(ReadFile(hFile, readConfigurationBuffer, (FILE_BUFFER_SIZE-1), &bytesRead, NULL) == FALSE)
 	{
-		MessageBox(NULL, L"Failed to read the config file", L"Error", MB_OK | MB_ICONERROR);
+		MessageBox(NULL, TEXT("Failed to read the config file"), TEXT("Error"), MB_OK | MB_ICONERROR);
 		CloseHandle(hFile);
 		return 1;
 	}
@@ -80,7 +81,7 @@ int readConfigurationFileBuffer(char* const& resultConfigurationBuffer)
 	}
 	else
 	{
-		MessageBox(NULL, L"Unexpected value", L"Error", MB_OK | MB_ICONERROR);
+		MessageBox(NULL, TEXT("Unexpected value"), TEXT("Error"), MB_OK | MB_ICONERROR);
 		CloseHandle(hFile);
 		return 1;
 	}
@@ -186,24 +187,22 @@ int writeConfigurationFileBuffer(const char* const configurationBuffer)
 
 	if(hFile == INVALID_HANDLE_VALUE)
 	{
-		MessageBox(NULL, L"Failed to create config file", L"Error", MB_OK | MB_ICONERROR);
+		MessageBox(NULL, TEXT("Failed to create config file"), TEXT("Error"), MB_OK | MB_ICONERROR);
 		CloseHandle(hFile);
 		return 1;
-	} else { 
+	} 
 
-		errorFlag = WriteFile(hFile, configurationBuffer, bytesToWrite, &bytesWritten, NULL);
+	errorFlag = WriteFile(hFile, configurationBuffer, bytesToWrite, &bytesWritten, NULL);
 
-		if(FALSE == errorFlag)
-		{
-			MessageBox(NULL, L"Failed to write to config file", L"Error", MB_OK | MB_ICONERROR);
-			CloseHandle(hFile);
-			return 1;
-		}
-
+	if(!errorFlag)
+	{
+		MessageBox(NULL, TEXT("Failed to write to config file"), TEXT("Error"), MB_OK | MB_ICONERROR);
 		CloseHandle(hFile);
-		return 0;
+		return 1;
 	}
+
 	CloseHandle(hFile);
+	return 0;
 }
 
 
@@ -250,6 +249,7 @@ int extractValue(const char* const configurationBuffer, const char* const target
 
 
 
+
 /*
 *	Return the index of a key in a buffer if it exists.
 *	:param const char* const configurationBuffer: The string buffer to search.
@@ -258,68 +258,14 @@ int extractValue(const char* const configurationBuffer, const char* const target
 */
 int searchKeyIndex(const char* const configurationBuffer, const char* const targetKey)
 {
-	char * resultValueBuffer = (char*)malloc(sizeof(char) * FILE_BUFFER_SIZE);
-	int i = 0;
-	int j = 0;
-	int lowIndex = 0;
-	int highIndex = 0;
-	int resultBufferIndex = 0;
-	bool ignoreFound = FALSE;
-
-	for(i=0; i<FILE_BUFFER_SIZE; i++)
-	{
-		if(configurationBuffer[i] == '#')
-		{
-			ignoreFound = TRUE;
-		}
-
-		if(ignoreFound)
-		{
-			if(configurationBuffer[i] == ';')
-			{
-				ignoreFound = FALSE;
-				lowIndex = i;
-				resultBufferIndex = 0;
-			}
-		}
-		else
-		{
-			if(configurationBuffer[i] == ';')
-			{
-				for(j=lowIndex; j<=highIndex; j++)
-				{
-					if(configurationBuffer[j] == ';')
-					{
-						lowIndex = i+1;
-						resultBufferIndex = 0;
-						continue;
-					}
-
-					if(configurationBuffer[j] ==':')
-					{
-						resultValueBuffer[resultBufferIndex] = '\0';
-
-						if(compareKeys(resultValueBuffer, targetKey))
-						{
-							return j;
-						}
-						else
-						{
-							lowIndex = i+1;
-							resultBufferIndex = 0;
-							break;
-						}					
-					}
-					else
-					{
-						resultValueBuffer[resultBufferIndex] = configurationBuffer[j];
-						resultBufferIndex++;
-					}				
-				}			
-			}
-		}
-		highIndex++;		
+	const int buffLen = strlen(configurationBuffer);
+	const int targetLen = strlen(targetKey);
+	char* substr = new char[targetLen + 1];
+	for (int i = 0; i < buffLen - targetLen; i++) {
+		if (FAILED(StringCchCopyNA(substr, targetLen + 1, &configurationBuffer[i], targetLen))) return -1;
+		if (lstrcmpA(substr, targetKey) == 0) return i;
 	}
+	delete[] substr;
 	return -1;
 }
 
@@ -463,7 +409,7 @@ int isSetConfigurationValueTrue(const char* const targetKey)
 	{
 		if(setConfigurationValue(targetKey, "FALSE") == 1)
 		{
-			MessageBox(NULL, L"Failed to set the configuration option", L"Error", MB_OK | MB_ICONERROR);
+			MessageBox(NULL, TEXT("Failed to set the configuration option"), TEXT("Error"), MB_OK | MB_ICONERROR);
 		}
 		return FALSE;
 	}

--- a/windows/gui-source/KA Lite/config.h
+++ b/windows/gui-source/KA Lite/config.h
@@ -1,28 +1,24 @@
 #ifndef config
 #define config
 
-#define FILE_BUFFER_SIZE                            2048
+#define FILE_BUFFER_SIZE 2048
 
-
-
-/*
-*	Functions declaration.
-*/
-int readConfigurationFileBuffer(char * resultConfigurationBuffer);
-int writeConfigurationFileBuffer(char * configurationBuffer);
-bool compareKeys(const char * key1, const char * key2);
-int extractValue(const char * configurationBuffer, const char * targetKey, char * resultValue, int resultValueArraySize);
-int searchKeyIndex(const char * configurationBuffer, const char * targetKey);
-int addValue(const char * configurationBuffer, const char * targetKey, const char * value, char * resultConfigurationBuffer, int resultConfigurationBufferSize);
-void formatResultBuffer(const char * configurationBuffer, char * resultConfigurationBuffer);
-int getConfigurationValue(char * targetKey, char * resultValue, int resultValueBufferSize);
-int setConfigurationValue(const char * targetKey, const char * value);
-
+int readConfigurationFileBuffer(char* const& resultConfigurationBuffer);
+int writeConfigurationFileBuffer(const char* const configurationBuffer);
+bool compareKeys(const char* const key1, const char* const key2);
+int extractValue(const char* const configurationBuffer, const char* const targetKey, char* const& resultValue, int const resultValueArraySize);
+int searchKeyIndex(const char* const configurationBuffer, const char* const targetKey);
+int addValue(const char* const configurationBuffer, const char* const targetKey, const char* const value, char* const& resultConfigurationBuffer, int const resultConfigurationBufferSize);
+int formatResultBuffer(const char* const configurationBuffer, char* const& resultConfigurationBuffer, const int resultBufferSize);
+int isSetConfigurationValueTrue(const char* const targetKey);
+int setConfigurationValue(const char* const targetKey, const char* const value);
 
 /*
 *	Read the configuration file to some buffer.
+*	:param char* const& resultConfigurationBuffer: The buffer into which the configuration file is read.
+*	:returns int: 0 indicating success, or 1 indicating failure
 */
-int readConfigurationFileBuffer(char * resultConfigurationBuffer)
+int readConfigurationFileBuffer(char* const& resultConfigurationBuffer)
 {
 	HANDLE hFile;
 	DWORD bytesRead = 0;
@@ -88,8 +84,10 @@ int readConfigurationFileBuffer(char * resultConfigurationBuffer)
 
 /*
 *	Write the configuration file from some buffer.
+*	:param const char* const configurationBuffer: The buffer from which the configuration file is written.
+*	:returns int: 0 indicating success, or 1 indicating failure
 */
-int writeConfigurationFileBuffer(char * configurationBuffer)
+int writeConfigurationFileBuffer(const char* const configurationBuffer)
 {
 	HANDLE hFile;
 	DWORD bytesToWrite = (DWORD) strlen(configurationBuffer);
@@ -124,31 +122,26 @@ int writeConfigurationFileBuffer(char * configurationBuffer)
 
 /*
 *	Compare two buffers.
+*	:param const char* const key1, key2: The two string buffers to compare.
+*	:returns bool: true if the strings have the same content, otherwise false.
 */
-bool compareKeys(const char * key1, const char * key2)
+bool compareKeys(const char* const key1, const char* const key2)
 {
-	const int key1_size = (unsigned)strlen(key1);
-	const int key2_size = (unsigned)strlen(key2);
-
-	if(key1_size != key1_size) return false;
-
-	int size_test = 0;
-
-	while( (*key1++ == *key2++) && (size_test < key1_size) )
-	{
-		size_test++;
-	}
-
-	if( (size_test == key1_size) && (size_test == key2_size) ) return true;
 	return false;
 }
 
 
 
 /*
-*	Extract the value of a key if that key exists.
+*	Extract the value of a key from a buffer if that key is in the buffer.
+*	:param const char* const configurationBuffer: The string buffer to read from.
+*	:param const char* const targetKey: The string we're searching for.
+*	:char* const& resultValue: String buffer to hold result value.
+*	:int const resultValueArraySize: The size of the resultValue array.
+*
+*	:returns int: 0 for success, 1 if the targetKey is not found, 2 if the resultValue buffer is not long enough.
 */
-int extractValue(const char * configurationBuffer, const char * targetKey, char * resultValue, int resultValueArraySize)
+int extractValue(const char* const configurationBuffer, const char* const targetKey, char* const& resultValue, int const resultValueArraySize)
 {
 	int tempIndex = 0;
 	int index = searchKeyIndex(configurationBuffer, targetKey);
@@ -170,9 +163,12 @@ int extractValue(const char * configurationBuffer, const char * targetKey, char 
 
 
 /*
-*	Return the index of a key if it exists.
+*	Return the index of a key in a buffer if it exists.
+*	:param const char* const configurationBuffer: The string buffer to search.
+*	:param const char* const targetKey: The key to search for.
+*	:returns int: The index in configurationBuffer where the targetKey starts if found, otherwise -1.
 */
-int searchKeyIndex(const char * configurationBuffer, const char * targetKey)
+int searchKeyIndex(const char* const configurationBuffer, const char* const targetKey)
 {
 	char * resultValueBuffer = (char*)malloc(sizeof(char) * FILE_BUFFER_SIZE);
 	int i = 0;
@@ -242,9 +238,16 @@ int searchKeyIndex(const char * configurationBuffer, const char * targetKey)
 
 
 /*
-*	Updates the value of the given key or add it if it doesn't exist.
+*	Updates the value of the given key in a configuration buffer, or add it if it doesn't exist.
+*	:param const char* const configurationBuffer: The buffer to be searched
+*	:param const char* const targetKey: The key we're looking to update.
+*	:param const char* const value: The updated value to be set.
+*	:param char* const& resultConfigurationBuffer: Another buffer which will hold the updated buffer -- the original cofigurationBuffer is not modified.
+*	:param int const resultConfigurationBufferSize: the size of resultConfigurationBuffer.
+*
+*	:returns int: 0 on success, 1 if the targetKey or value strings are empty, 2 if resultConfigurationBuffer is not long enough.
 */
-int addValue(const char * configurationBuffer, const char * targetKey, const char * value, char * resultConfigurationBuffer, int resultConfigurationBufferSize)
+int addValue(const char* const configurationBuffer, const char* const targetKey, const char* const value, char* const& resultConfigurationBuffer, int const resultConfigurationBufferSize)
 {
 	const int key_size = (unsigned)strlen(targetKey);
 	const int value_size = (unsigned)strlen(value);
@@ -326,8 +329,13 @@ int addValue(const char * configurationBuffer, const char * targetKey, const cha
 
 /*
 *	Prepare the buffer for file writing.
+*	:param const char* const configurationBuffer: The input buffer to be prepared.
+*	:param char* const& resultConfigurationBuffer: Another buffer to hold the output.
+*	:param const int resultBufferSize: The size of resultConfigurationBuffer.
+*
+*	:returns int: 0 on success, 2 if resultConfigurationBuffer is not long enough.
 */
-void formatResultBuffer(char * configurationBuffer, char * resultConfigurationBuffer)
+int formatResultBuffer(const char* const configurationBuffer, char* const& resultConfigurationBuffer, const int resultBufferSize)
 {
 	int i = 0;
 	int tempIndex = 0;
@@ -350,8 +358,10 @@ void formatResultBuffer(char * configurationBuffer, char * resultConfigurationBu
 
 /*
 *	Read key from configuration file.
+*	:param const char* const targetKey: The key to check.
+*	:returns int: TRUE if the file has the key and it's set to "TRUE", otherwise FALSE. TRUE and FALSE are defined by preprocessor directives.
 */
-int isSetConfigurationValueTrue(char * targetKey)
+int isSetConfigurationValueTrue(const char* const targetKey)
 {
 	char configurationFileBuffer[FILE_BUFFER_SIZE];
 
@@ -380,9 +390,11 @@ int isSetConfigurationValueTrue(char * targetKey)
 
 
 /*
-*	General write key to configuration file.
+*	Write a key-value pair to the configuration file.
+*	:param const char* const targetKey, value: The key-value pair strings to be written.
+*	:reutns int: 0 on success, 1 on any other error.
 */
-int setConfigurationValue(const char * targetKey, const char * value)
+int setConfigurationValue(const char* const targetKey, const char* const value)
 {
 	char configurationFileBuffer[FILE_BUFFER_SIZE];
 	char resultConfigurationBuffer[FILE_BUFFER_SIZE];

--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -243,7 +243,7 @@ var
     prevVerStr : String;
 begin
     prevVerStr := GetPreviousVersion();
-    if CompareStr('{#TargetVersion}', prevVerStr) >= 0 then
+    if (CompareStr('{#TargetVersion}', prevVerStr) >= 0) and not (prevVerStr = '') then
     begin
         ConfirmUpgradeDialog;
         if Not isUpgrade then
@@ -275,11 +275,13 @@ begin
                     MoveSystemKaliteData;
                 end;
             end;
-
         end;
-    { forceCancel will be true if something went awry in DoGitMigrate... abort instead of trampling the user's data. }
-    if Not forceCancel then
-        RemoveOldInstallation(targetPath);
+
+        { forceCancel will be true if something went awry in DoGitMigrate... abort instead of trampling the user's data. }
+        if Not forceCancel then
+        begin
+            RemoveOldInstallation(targetPath);
+        end;
     end;
 end;
 

--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -206,8 +206,28 @@ end;
 { SYSTEM user's profile to the new location. }
 procedure WarnAboutSystemData;
 var
+    systemKaliteDir: String;
+    userKaliteDir: String;
+    userKaliteDirBackup: String;
 begin
-    MsgBox('You may need to migrate data from the SYSTEM user''s profile to the current user''s profile.', mbInformation, MB_OK);
+    systemKaliteDir := 'C:\Windows\System32\config\systemprofile\.kalite';
+    if DirExists(systemKaliteDir) then
+    begin
+        if(MsgBox('You may need to migrate data from the SYSTEM user''s profile to the current user''s profile.' #13#13
+                  'This is because of a change in the behavior of KA Lite using the "Start at system start..." option' #13#13
+                  'If you use this option, we recommend clicking yes. Your data will be backed up.' #13#13
+                  'Would you like to migrate data from the SYSTEM user''s profile to the current user''s profile?', mbConfirmation, MB_YESNO) = idYes) then
+        begin
+            userKaliteDir := ExpandConstant('{%USERPROFILE}\.kalite');
+            userKaliteDirBackup := userKaliteDir + '.backup';
+            if DirExists(userKaliteDir) then
+            begin
+                MsgBox(userKaliteDir + ' already exists, backing up to ' + userKaliteDirBackup, mbInformation, MB_OK);
+                FileCopy(userKaliteDir, userKaliteDirBackup, False);
+            end;
+            FileCopy(systemKaliteDir, userKaliteDir, False);
+        end;
+    end;
 end;
 
 procedure HandleUpgrade(targetPath : String);
@@ -238,7 +258,7 @@ begin
             end;
 
             { Migrating from 0.14.x and 0.15.x to 0.16.x }
-            if CompareStr(prevVerStr, '0.14.0') >= 0 and CompareStr(prevVerStr, '0.15.99') < 0 then
+            if (CompareStr(prevVerStr, '0.14.0') >= 0) and (CompareStr(prevVerStr, '0.15.99') < 0) then
             begin
                 if CompareStr('{#TargetVersion}', '0.16.0') >= 0 then
                 begin

--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -201,6 +201,15 @@ begin
     end;
 end;
 
+{ In version 0.13.x or below, users who selected the "Run KA Lite at system startup" option ran KA Lite as the }
+{ SYSTEM user. Starting in 0.16.0, it will be run as the current user. Consequently, data must be migrated from the }
+{ SYSTEM user's profile to the new location. }
+procedure WarnAboutSystemData;
+var
+begin
+    MsgBox('You may need to migrate data from the SYSTEM user''s profile to the current user''s profile.', mbInformation, MB_OK);
+end;
+
 procedure HandleUpgrade(targetPath : String);
 begin
     GetPreviousVersion;
@@ -219,6 +228,7 @@ begin
         else
         begin
             { This is where version-specific migration stuff should happen. }
+
             if CompareStr(prevVerStr, '0.13.99') < 0 then
             begin
                 if CompareStr('{#TargetVersion}', '0.14.0') >= 0 then
@@ -226,6 +236,16 @@ begin
                     DoGitMigrate;
                 end;
             end;
+
+            { Migrating from 0.14.x and 0.15.x to 0.16.x }
+            if CompareStr(prevVerStr, '0.14.0') >= 0 and CompareStr(prevVerStr, '0.15.99') < 0 then
+            begin
+                if CompareStr('{#TargetVersion}', '0.16.0') >= 0 then
+                begin
+                    WarnAboutSystemData;
+                end;
+            end;
+
         end;
     { forceCancel will be true if something went awry in DoGitMigrate... abort instead of trampling the user's data. }
     if Not forceCancel then

--- a/windows/scripts/add_systemstart_task.bat
+++ b/windows/scripts/add_systemstart_task.bat
@@ -9,5 +9,5 @@ if %WIN_VERSION% LEQ "5.2" (
     echo This feature is unavailable on this version of Windows.
     pause
 ) else (
-    schtasks /create /tn "KALite" /tr "\"%KALITE_SCRIPT_DIR%\kalite.bat\" start" /sc onstart /ru SYSTEM /f
+    schtasks /create /tn "KALite" /tr "\"%KALITE_SCRIPT_DIR%\kalite.bat\" start" /sc onstart /ru %USERNAME% /f
 )


### PR DESCRIPTION
Still a WIP. Will fix #321.

Todo:
- [x] Remove the ability to create CONFIG.dat at install time
- [x] Write CONFIG.dat to a location determined by the user running KA Lite.exe
- [x] Do some clean-up refactoring on `config.h`.
- [x] Migrate data from location dependent on Windows version to installing user's ~/.kalite dir.
- [x] Change the start at boot option so that it run's as the current user instead of SYSTEM

Will appreciate a code review. I am but an egg with C++\Windows dev. Willing to discuss in great detail.