### PR TITLE
Feature/338 tooltip help isnt too user friendly part 2

### DIFF
--- a/osx/KA-Lite/KA-Lite.xcodeproj/project.pbxproj
+++ b/osx/KA-Lite/KA-Lite.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 47;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -180,7 +180,7 @@
 				};
 			};
 			buildConfigurationList = F1DDD4071A6E5DC10022F1C9 /* Build configuration list for PBXProject "KA-Lite" */;
-			compatibilityVersion = "Xcode 3.2";
+			compatibilityVersion = "Xcode 6.3";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/osx/KA-Lite/KA-Lite/AppDelegate.h
+++ b/osx/KA-Lite/KA-Lite/AppDelegate.h
@@ -15,7 +15,6 @@
     IBOutlet id window;
 }
 
-- (void)closeSplash;
 
 @property (weak) IBOutlet NSButton *startButton;
 @property (weak) IBOutlet NSButton *stopButton;
@@ -45,6 +44,8 @@
 
 @property (weak) IBOutlet NSPopover *popover;
 @property (weak) IBOutlet NSTextField *popoverMsg;
+@property (weak) IBOutlet NSView *aView;
+
 
 enum kaliteStatus {
     statusOkRunning = 0,
@@ -61,6 +62,9 @@ enum kaliteStatus {
 };
 
 @property enum kaliteStatus status;
+
+
+- (void)closeSplash;
 
 
 @end

--- a/osx/KA-Lite/KA-Lite/AppDelegate.h
+++ b/osx/KA-Lite/KA-Lite/AppDelegate.h
@@ -43,6 +43,9 @@
 @property (weak) IBOutlet NSButton *kaliteDataHelp;
 @property (weak) IBOutlet NSButton *savePrefs;
 
+@property (weak) IBOutlet NSPopover *popover;
+@property (weak) IBOutlet NSTextField *popoverMsg;
+
 enum kaliteStatus {
     statusOkRunning = 0,
     statusStopped = 1,

--- a/osx/KA-Lite/KA-Lite/AppDelegate.m
+++ b/osx/KA-Lite/KA-Lite/AppDelegate.m
@@ -21,7 +21,7 @@
 
 @implementation AppDelegate
 
-@synthesize startKalite, stopKalite, openInBrowserMenu, kaliteVersion, customKaliteData, startOnLogin, kaliteDataHelp;
+@synthesize startKalite, stopKalite, openInBrowserMenu, kaliteVersion, customKaliteData, startOnLogin, kaliteDataHelp, popover, popoverMsg;
 
 
 // REF: http://objcolumnist.com/2009/08/09/reopening-an-applications-main-window-by-clicking-the-dock-icon/
@@ -639,11 +639,17 @@ NSString *getEnvVar(NSString *var) {
 }
 
 - (IBAction)uninstallHelp:(id)sender {
-    alert(@"This will uninstall the KA Lite application. \n \nCheck the `Delete KA Lite data folder` option if you want to delete your KA Lite data. \n \nNOTE: This will require admin privileges.");
+    
+    [popoverMsg setTitleWithMnemonic:@"This will uninstall the KA Lite application. \n \nCheck the `Delete KA Lite data folder` option if you want to delete your KA Lite data. \n \nNOTE: This will require admin privileges."];
+    
+    [popover showRelativeToRect:[sender bounds] ofView:sender preferredEdge:NSMaxXEdge];
+    
 }
 
 - (IBAction)kaliteDataHelp:(id)sender {
-    alert(@"This will set the KALITE_HOME environment variable to the selected KA Lite data location. \n \nClick the 'Apply' button to save your changes and click the 'Start KA Lite' button to use your new data location. \n \nNOTE: To use your existing KA Lite data, manually copy it to the selected KA Lite data location.");
+    [popoverMsg setTitleWithMnemonic:@"This will set the KALITE_HOME environment variable to the selected KA Lite data location. \n \nClick the 'Apply' button to save your changes and click the 'Start KA Lite' button to use your new data location. \n \nNOTE: To use your existing KA Lite data, manually copy it to the selected KA Lite data location."];
+
+    [popover showRelativeToRect:[sender bounds] ofView:sender preferredEdge:NSMaxXEdge];
 }
 
 - (void)closeSplash {

--- a/osx/KA-Lite/KA-Lite/AppDelegate.m
+++ b/osx/KA-Lite/KA-Lite/AppDelegate.m
@@ -15,10 +15,6 @@
 
 @import Foundation;
 
-@interface AppDelegate ()
-//    @property (weak) IBOutlet NSWindow *window;
-@end
-
 @implementation AppDelegate
 
 @synthesize startKalite, stopKalite, openInBrowserMenu, kaliteVersion, customKaliteData, startOnLogin, kaliteDataHelp, popover, popoverMsg;
@@ -523,16 +519,6 @@ NSString *getEnvVar(NSString *var) {
 }
 
 
-- (IBAction)start:(id)sender {
-    [self startFunction];
-}
-
-
-- (IBAction)startButton:(id)sender {
-    [self startFunction];
-}
-
-
 - (void)stopFunction {
     showNotification(@"Stopping...");
     if (self.processCounter != 0) {
@@ -540,6 +526,26 @@ NSString *getEnvVar(NSString *var) {
         return;
     }
     [self runKalite:@"stop"];
+}
+
+
+- (void)openFunction {
+    // REF: http://stackoverflow.com/a/7129543/845481
+    NSURL *url = [NSURL URLWithString:@"http://127.0.0.1:8008/"];
+    if( ![[NSWorkspace sharedWorkspace] openURL:url] ) {
+        NSString *msg = [NSString stringWithFormat:@" Failed to open url: %@",[url description]];
+        showNotification(msg);
+    }
+}
+
+
+- (IBAction)start:(id)sender {
+    [self startFunction];
+}
+
+
+- (IBAction)startButton:(id)sender {
+    [self startFunction];
 }
 
 
@@ -552,22 +558,14 @@ NSString *getEnvVar(NSString *var) {
     [self stopFunction];
 }
 
+
 - (IBAction)customKaliteData:(id)sender {
     self.savePrefs.enabled = TRUE;
 }
 
+
 - (IBAction)startOnLogin:(id)sender {
     self.savePrefs.enabled = TRUE;
-}
-
-- (void)openFunction {
-    // TODO(cpauya): Get the ip address and port from `local_settings.py` or preferences.
-    // REF: http://stackoverflow.com/a/7129543/845481
-    NSURL *url = [NSURL URLWithString:@"http://127.0.0.1:8008/"];
-    if( ![[NSWorkspace sharedWorkspace] openURL:url] ) {
-        NSString *msg = [NSString stringWithFormat:@" Failed to open url: %@",[url description]];
-        showNotification(msg);
-    }
 }
 
 
@@ -601,12 +599,14 @@ NSString *getEnvVar(NSString *var) {
     [self savePreferences];
 }
 
+
 - (IBAction)discardPreferences:(id)sender {
     [self discardPreferences];
 }
 
+
 - (IBAction)kaliteUninstall:(id)sender {
-        
+    
     // Get the KA Lite application directory path.
     NSString *appPath = [[NSBundle mainBundle] bundlePath];
     // REF: http://stackoverflow.com/questions/7469425/how-to-parse-nsstring-by-removing-2-folders-in-path-in-objective-c
@@ -638,23 +638,23 @@ NSString *getEnvVar(NSString *var) {
     }
 }
 
+
 - (IBAction)uninstallHelp:(id)sender {
-    
-    [popoverMsg setTitleWithMnemonic:@"This will uninstall the KA Lite application. \n \nCheck the `Delete KA Lite data folder` option if you want to delete your KA Lite data. \n \nNOTE: This will require admin privileges."];
-    
-    [popover showRelativeToRect:[sender bounds] ofView:sender preferredEdge:NSMaxXEdge];
-    
+    NSString* msg = @"This will uninstall the KA Lite application. \n \nCheck the `Delete KA Lite data folder` option if you want to delete your KA Lite data. \n \nNOTE: This will require admin privileges.";
+    [self showPopOver:sender withMsg:msg];
 }
+
 
 - (IBAction)kaliteDataHelp:(id)sender {
-    [popoverMsg setTitleWithMnemonic:@"This will set the KALITE_HOME environment variable to the selected KA Lite data location. \n \nClick the 'Apply' button to save your changes and click the 'Start KA Lite' button to use your new data location. \n \nNOTE: To use your existing KA Lite data, manually copy it to the selected KA Lite data location."];
-
-    [popover showRelativeToRect:[sender bounds] ofView:sender preferredEdge:NSMaxXEdge];
+    NSString* msg = @"This will set the KALITE_HOME environment variable to the selected KA Lite data location. \n \nClick the 'Apply' button to save your changes and click the 'Start KA Lite' button to use your new data location. \n \nNOTE: To use your existing KA Lite data, manually copy it to the selected KA Lite data location.\n \nFor more information, please refer to the README document.";
+    [self showPopOver:sender withMsg:msg];
 }
+
 
 - (void)closeSplash {
     [splash orderOut:self];
 }
+
 
 - (void)showPreferences {
     [splash orderOut:self];
@@ -736,14 +736,34 @@ NSString *getEnvVar(NSString *var) {
 }
 
 
+- (void)showPopOver:(id)sender withMsg:(NSString*) msg {
+    [popoverMsg setStringValue:msg];
+    
+    // Show the popover first, then set it's size so it is rendered correctly.
+    [popover showRelativeToRect:[sender bounds] ofView:sender preferredEdge:NSMaxXEdge];
+
+    // REF: http://stackoverflow.com/a/16239550/845481
+    // Getting NSTextView to perfectly fit its contents
+    NSString *text = popoverMsg.stringValue;
+    NSSize newSize = NSMakeSize(popoverMsg.bounds.size.width, 0);
+    NSStringDrawingOptions options = NSStringDrawingUsesLineFragmentOrigin;
+    NSRect bounds = [text boundingRectWithSize:newSize options:options attributes:nil];
+    // TODO(cpauya): Using this code on a popover with shorter height yields an extra space at the
+    // bottom.  Find a way to remove that without affecting the other popover with longer height.
+    NSRect rect = NSMakeRect(0, 0, newSize.width, bounds.size.height + 50);
+    popoverMsg.frame = rect;
+    popover.contentSize = rect.size;
+}
+
+
 BOOL setEnvVars() {
     
-    //REF: http://stackoverflow.com/questions/99395/how-to-check-if-a-folder-exists-in-cocoa-objective-c
+    // REF: http://stackoverflow.com/questions/99395/how-to-check-if-a-folder-exists-in-cocoa-objective-c
     // Check if home Library/LaunchAgents/ path exist.
     NSString *LibraryLaunchAgentPath = [NSString stringWithFormat:@"%@%@", NSHomeDirectory(), @"/Library/LaunchAgents/"];
     NSFileManager*fm = [NSFileManager defaultManager];
     if(![fm fileExistsAtPath:LibraryLaunchAgentPath]) {
-        //REF: http://stackoverflow.com/questions/99395/how-to-check-if-a-folder-exists-in-cocoa-objective-c
+        // REF: http://stackoverflow.com/questions/99395/how-to-check-if-a-folder-exists-in-cocoa-objective-c
         // Create home Library/LaunchAgents/ path.
         NSError * error = nil;
         BOOL success = [[NSFileManager defaultManager] createDirectoryAtPath: LibraryLaunchAgentPath

--- a/osx/KA-Lite/KA-Lite/en.lproj/MainMenu.xib
+++ b/osx/KA-Lite/KA-Lite/en.lproj/MainMenu.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="14F27" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7706"/>
+        <development version="6300" identifier="xcode"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -12,6 +13,32 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <customView id="pZI-cL-XQn">
+            <rect key="frame" x="0.0" y="0.0" width="311" height="187"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <subviews>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zKN-e6-XtP">
+                    <rect key="frame" x="4" y="5" width="304" height="176"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="4jU-XX-dzN">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+            </subviews>
+            <point key="canvasLocation" x="411.5" y="74.5"/>
+        </customView>
+        <viewController id="WPK-6f-Onm" userLabel="Popover View Controller">
+            <connections>
+                <outlet property="view" destination="pZI-cL-XQn" id="sYl-rK-MfO"/>
+            </connections>
+        </viewController>
+        <popover id="AAs-fZ-3f7">
+            <connections>
+                <outlet property="contentViewController" destination="WPK-6f-Onm" id="yDs-gD-ZV6"/>
+                <outlet property="delegate" destination="Voe-Tx-rLC" id="wZR-JL-ggj"/>
+            </connections>
+        </popover>
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate">
             <connections>
                 <outlet property="customKaliteData" destination="Fr9-lD-cxj" id="RLj-fb-pMb"/>
@@ -21,6 +48,8 @@
                 <outlet property="kaliteVersion" destination="89o-4x-JIp" id="72c-bS-dBh"/>
                 <outlet property="openBrowserButton" destination="wxg-iv-YDa" id="0er-aA-Ymn"/>
                 <outlet property="openInBrowserMenu" destination="z2m-ls-Z0I" id="mGN-C0-zz5"/>
+                <outlet property="popover" destination="AAs-fZ-3f7" id="Dbq-r8-eq8"/>
+                <outlet property="popoverMsg" destination="zKN-e6-XtP" id="376-0e-BSm"/>
                 <outlet property="savePrefs" destination="3rc-kc-VMj" id="bt8-CV-3fm"/>
                 <outlet property="splash" destination="izD-1r-MWo" id="ax5-nI-Mu0"/>
                 <outlet property="startButton" destination="Eur-YG-XhD" id="I4H-kx-9AL"/>
@@ -143,12 +172,12 @@ Gw
                         <font key="font" metaFont="system" size="14"/>
                         <tabViewItems>
                             <tabViewItem label="Preferences" identifier="1" id="bsG-cY-LW8">
-                                <view key="view" id="B8D-my-NmZ">
-                                    <rect key="frame" x="10" y="33" width="447" height="328"/>
+                                <view key="view" ambiguous="YES" id="B8D-my-NmZ">
+                                    <rect key="frame" x="10" y="33" width="130" height="0.0"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Eur-YG-XhD">
-                                            <rect key="frame" x="11" y="269" width="119" height="32"/>
+                                            <rect key="frame" x="11" y="-59" width="119" height="32"/>
                                             <buttonCell key="cell" type="push" title="Start KA Lite" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="AIv-42-gwi">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -158,7 +187,7 @@ Gw
                                             </connections>
                                         </button>
                                         <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ixV-cY-gLJ">
-                                            <rect key="frame" x="153" y="269" width="118" height="32"/>
+                                            <rect key="frame" x="153" y="-59" width="118" height="32"/>
                                             <buttonCell key="cell" type="push" title="Stop KA Lite" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Liy-0e-2VH">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -168,7 +197,7 @@ Gw
                                             </connections>
                                         </button>
                                         <box autoresizesSubviews="NO" fixedFrame="YES" borderType="line" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="PbE-4O-LPb">
-                                            <rect key="frame" x="14" y="205" width="419" height="53"/>
+                                            <rect key="frame" x="14" y="-123" width="419" height="53"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="417" height="51"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -213,7 +242,7 @@ Gw
                                             <font key="titleFont" metaFont="systemBold"/>
                                         </box>
                                         <box autoresizesSubviews="NO" fixedFrame="YES" title="Uninstall KA Lite" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="2Uh-zQ-2n5">
-                                            <rect key="frame" x="14" y="5" width="419" height="82"/>
+                                            <rect key="frame" x="14" y="-323" width="419" height="82"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="417" height="63"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -252,7 +281,7 @@ Gw
                                             <font key="titleFont" metaFont="systemBold"/>
                                         </box>
                                         <box autoresizesSubviews="NO" fixedFrame="YES" title="Application behavior" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="Sqz-dv-Dpy">
-                                            <rect key="frame" x="14" y="101" width="419" height="91"/>
+                                            <rect key="frame" x="14" y="-227" width="419" height="91"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="417" height="72"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -281,7 +310,7 @@ Gw
                                             <font key="titleFont" metaFont="systemBold"/>
                                         </box>
                                         <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wxg-iv-YDa">
-                                            <rect key="frame" x="293" y="269" width="143" height="32"/>
+                                            <rect key="frame" x="293" y="-59" width="143" height="32"/>
                                             <buttonCell key="cell" type="push" title="Open in Browser" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="49I-m5-mkT">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -300,12 +329,12 @@ Gw
                                     <subviews>
                                         <scrollView fixedFrame="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="45z-rP-1Bz">
                                             <rect key="frame" x="-3" y="30" width="453" height="295"/>
-                                            <clipView key="contentView" misplaced="YES" id="byO-FJ-ADZ">
-                                                <rect key="frame" x="1" y="1" width="223" height="133"/>
+                                            <clipView key="contentView" ambiguous="YES" id="byO-FJ-ADZ">
+                                                <rect key="frame" x="1" y="1" width="436" height="293"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <textView editable="NO" importsGraphics="NO" findStyle="panel" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" usesFontPanel="YES" verticallyResizable="YES" allowsNonContiguousLayout="YES" quoteSubstitution="YES" dashSubstitution="YES" spellingCorrection="YES" smartInsertDelete="YES" id="ggK-co-dOR">
-                                                        <rect key="frame" x="0.0" y="0.0" width="223" height="293"/>
+                                                    <textView ambiguous="YES" editable="NO" importsGraphics="NO" findStyle="panel" continuousSpellChecking="YES" allowsUndo="YES" usesRuler="YES" usesFontPanel="YES" verticallyResizable="YES" allowsNonContiguousLayout="YES" quoteSubstitution="YES" dashSubstitution="YES" spellingCorrection="YES" smartInsertDelete="YES" id="ggK-co-dOR">
+                                                        <rect key="frame" x="0.0" y="0.0" width="436" height="293"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                         <size key="minSize" width="436" height="293"/>
@@ -321,8 +350,8 @@ Gw
                                                 <rect key="frame" x="-100" y="-100" width="87" height="18"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
-                                            <scroller key="verticalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="RPA-mO-93H">
-                                                <rect key="frame" x="224" y="1" width="15" height="133"/>
+                                            <scroller key="verticalScroller" verticalHuggingPriority="750" horizontal="NO" id="RPA-mO-93H">
+                                                <rect key="frame" x="1" y="1" width="15" height="0.0"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
                                         </scrollView>
@@ -353,7 +382,7 @@ Gw
                     </button>
                 </subviews>
             </view>
-            <point key="canvasLocation" x="733.5" y="285.5"/>
+            <point key="canvasLocation" x="747.5" y="274.5"/>
         </window>
         <userDefaultsController representsSharedInstance="YES" id="a2C-ep-hKK"/>
         <drawer trailingOffset="15" id="xf9-7j-N5c">

--- a/osx/KA-Lite/KA-Lite/en.lproj/MainMenu.xib
+++ b/osx/KA-Lite/KA-Lite/en.lproj/MainMenu.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="14F27" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <development version="6300" identifier="xcode"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
+        <capability name="box content view" minToolsVersion="7.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -14,33 +14,34 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="pZI-cL-XQn">
-            <rect key="frame" x="0.0" y="0.0" width="311" height="187"/>
+            <rect key="frame" x="0.0" y="0.0" width="213" height="335"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zKN-e6-XtP">
-                    <rect key="frame" x="4" y="5" width="304" height="176"/>
-                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="4jU-XX-dzN">
+                <textField canDrawConcurrently="YES" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8q5-Rg-nPu">
+                    <rect key="frame" x="0.0" y="20" width="213" height="315"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" drawsBackground="YES" id="uiv-Q8-ee6">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
             </subviews>
-            <point key="canvasLocation" x="411.5" y="74.5"/>
+            <point key="canvasLocation" x="142.5" y="123.5"/>
         </customView>
         <viewController id="WPK-6f-Onm" userLabel="Popover View Controller">
             <connections>
                 <outlet property="view" destination="pZI-cL-XQn" id="sYl-rK-MfO"/>
             </connections>
         </viewController>
-        <popover id="AAs-fZ-3f7">
+        <popover behavior="t" id="AAs-fZ-3f7">
             <connections>
                 <outlet property="contentViewController" destination="WPK-6f-Onm" id="yDs-gD-ZV6"/>
-                <outlet property="delegate" destination="Voe-Tx-rLC" id="wZR-JL-ggj"/>
+                <outlet property="delegate" destination="Voe-Tx-rLC" id="a7m-j9-tQG"/>
             </connections>
         </popover>
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate">
             <connections>
+                <outlet property="aView" destination="pZI-cL-XQn" id="4qq-fO-dqH"/>
                 <outlet property="customKaliteData" destination="Fr9-lD-cxj" id="RLj-fb-pMb"/>
                 <outlet property="deleteKaliteData" destination="ogp-QS-1iO" id="PQn-Dn-Yqa"/>
                 <outlet property="kaliteDataHelp" destination="IFr-HI-gEe" id="Vyj-fM-fsS"/>
@@ -49,7 +50,7 @@
                 <outlet property="openBrowserButton" destination="wxg-iv-YDa" id="0er-aA-Ymn"/>
                 <outlet property="openInBrowserMenu" destination="z2m-ls-Z0I" id="mGN-C0-zz5"/>
                 <outlet property="popover" destination="AAs-fZ-3f7" id="Dbq-r8-eq8"/>
-                <outlet property="popoverMsg" destination="zKN-e6-XtP" id="376-0e-BSm"/>
+                <outlet property="popoverMsg" destination="8q5-Rg-nPu" id="3eN-Ef-zJq"/>
                 <outlet property="savePrefs" destination="3rc-kc-VMj" id="bt8-CV-3fm"/>
                 <outlet property="splash" destination="izD-1r-MWo" id="ax5-nI-Mu0"/>
                 <outlet property="startButton" destination="Eur-YG-XhD" id="I4H-kx-9AL"/>
@@ -102,7 +103,7 @@
         <window title="Starting KA Lite..." allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" animationBehavior="default" id="izD-1r-MWo">
             <windowStyleMask key="styleMask" titled="YES"/>
             <rect key="contentRect" x="565" y="404" width="216" height="135"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1057"/>
             <view key="contentView" id="X7G-oL-gsN">
                 <rect key="frame" x="0.0" y="0.0" width="216" height="135"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -129,7 +130,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" unifiedTitleAndToolbar="YES"/>
             <windowCollectionBehavior key="collectionBehavior" canJoinAllSpaces="YES" managed="YES" participatesInCycle="YES"/>
             <rect key="contentRect" x="131" y="158" width="493" height="417"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1057"/>
             <view key="contentView" id="TP3-Cd-o99">
                 <rect key="frame" x="0.0" y="0.0" width="493" height="417"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -173,7 +174,7 @@ Gw
                         <tabViewItems>
                             <tabViewItem label="Preferences" identifier="1" id="bsG-cY-LW8">
                                 <view key="view" ambiguous="YES" id="B8D-my-NmZ">
-                                    <rect key="frame" x="10" y="33" width="130" height="0.0"/>
+                                    <rect key="frame" x="10" y="33" width="128" height="0.0"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Eur-YG-XhD">
@@ -198,7 +199,7 @@ Gw
                                         </button>
                                         <box autoresizesSubviews="NO" fixedFrame="YES" borderType="line" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="PbE-4O-LPb">
                                             <rect key="frame" x="14" y="-123" width="419" height="53"/>
-                                            <view key="contentView">
+                                            <view key="contentView" id="YHW-HJ-bTo">
                                                 <rect key="frame" x="1" y="1" width="417" height="51"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
@@ -243,7 +244,7 @@ Gw
                                         </box>
                                         <box autoresizesSubviews="NO" fixedFrame="YES" title="Uninstall KA Lite" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="2Uh-zQ-2n5">
                                             <rect key="frame" x="14" y="-323" width="419" height="82"/>
-                                            <view key="contentView">
+                                            <view key="contentView" id="noi-EB-vce">
                                                 <rect key="frame" x="1" y="1" width="417" height="63"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
@@ -282,7 +283,7 @@ Gw
                                         </box>
                                         <box autoresizesSubviews="NO" fixedFrame="YES" title="Application behavior" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="Sqz-dv-Dpy">
                                             <rect key="frame" x="14" y="-227" width="419" height="91"/>
-                                            <view key="contentView">
+                                            <view key="contentView" id="O91-s2-ClK">
                                                 <rect key="frame" x="1" y="1" width="417" height="72"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>


### PR DESCRIPTION
Hi @aronasorman - this fixes #338.  This is based on the initial work by @amodia.

We now use a [Popover](https://developer.apple.com/library/prerelease/mac/documentation/UserExperience/Conceptual/OSXHIGuidelines/ControlsView.html#//apple_ref/doc/uid/20000957-CH52-SW2) instead of the alert dialog when the "?" button is clicked by the user.  This is more user-friendly than the tooltip and more appropriate than the alert.  It also shows the context of the field where the "?" belongs.

Here's a screenshot:
<img width="670" alt="screenshot 2016-01-25 11 39 45" src="https://cloud.githubusercontent.com/assets/175580/12542017/b884b9c4-c358-11e5-9391-a0c2313975f2.png">