### PR TITLE
[Windows] Fix new scheduled task behavior

### DIFF
--- a/windows/scripts/add_systemstart_task.bat
+++ b/windows/scripts/add_systemstart_task.bat
@@ -9,5 +9,5 @@ if %WIN_VERSION% LEQ "5.2" (
     echo This feature is unavailable on this version of Windows.
     pause
 ) else (
-    schtasks /create /tn "KALite" /tr "\"%KALITE_SCRIPT_DIR%\kalite.bat\" start" /sc onstart /ru %USERNAME% /f
+    schtasks /create /tn "KALite" /tr "\"%KALITE_SCRIPT_DIR%\kalite.bat\" start" /sc onstart /ru %USERNAME% /rp /f
 )


### PR DESCRIPTION
Fixes #345. Commit messages below:

### Enabling system start task prompts user for password
```text
This is because Windows will refuse to start the KA Lite server
in the background *before* the user logs in if the password is
not provided. Note that passing the /np (no password) flag will
cause the task to *attempt* to start, but it will fail because
"no logon server could process the request".
```

### 	When upgrading to 0.16.0, remove old "KALite" scheduled task
```
It's run as the SYSTEM user, which has been an error since
0.13.0 -- see #345. Delete it so we can start fresh.
```
