### PR TITLE
Hotfix/349 os x package installer on bamboo is not code signed

### DIFF
--- a/osx/KA-Lite-Packages/docs/README.rst.rtf
+++ b/osx/KA-Lite-Packages/docs/README.rst.rtf
@@ -7,7 +7,7 @@
 {\list\listtemplateid4\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{disc\}}{\leveltext\leveltemplateid301\'01\uc0\u8226 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listname ;}\listid4}
 {\list\listtemplateid5\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{disc\}}{\leveltext\leveltemplateid401\'01\uc0\u8226 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listname ;}\listid5}}
 {\*\listoverridetable{\listoverride\listid1\listoverridecount0\ls1}{\listoverride\listid2\listoverridecount0\ls2}{\listoverride\listid3\listoverridecount0\ls3}{\listoverride\listid4\listoverridecount0\ls4}{\listoverride\listid5\listoverridecount0\ls5}}
-\paperw12240\paperh15840\margl1440\margr1440\vieww14040\viewh13180\viewkind0
+\paperw12240\paperh15840\margl1440\margr1440\vieww14040\viewh12740\viewkind0
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural
 
 \f0\b\fs24 \cf0 \ul \ulc0 Release Notes for 0.16.0
@@ -27,7 +27,7 @@ Other known issues:\
 \b0 \
 \pard\tx220\tx720\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural
 \ls2\ilvl0\cf0 {\listtext	\'95	}NEW - We now support Mac OS X 10.11 El Capitan.\
-{\listtext	\'95	}NEW - We now use a .pkg installer which uses a setup wizard GUI.  We also confirm to restart the computer to complete the installation.\
+{\listtext	\'95	}NEW - We now use a .pkg installer which uses a setup wizard GUI.\
 {\listtext	\'95	}NEW - We now bundle the `KA-Lite.app`, `README.md`, `LICENSE`, `RELEASE_NOTES.md`, and `KA-Lite_Uninstall.tool` script inside the `/Applications/KA-Lite/` folder.\
 {\listtext	\'95	}NEW - We now have a pre-installation script that checks for a previous installation if it exists and does the following:\
 \pard\tx940\tx1440\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li1440\fi-1440\pardirnatural
@@ -95,7 +95,7 @@ If you encounter issues, please file them at the KA Lite Installers repository -
 \
 Please note that we have tested this application on the following Mac OS X versions:\
 \pard\tx220\tx720\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural
-\ls5\ilvl0\cf0 {\listtext	\'95	}OS X El Capitan - version 10.11.1\
+\ls5\ilvl0\cf0 {\listtext	\'95	}OS X El Capitan - version 10.11.3\
 {\listtext	\'95	}OS X Yosemite - version 10.10.5\
 {\listtext	\'95	}OS X Mavericks - version 10.9.5\
 }

--- a/osx/build.sh
+++ b/osx/build.sh
@@ -299,12 +299,12 @@ fi
 
 # Check if to codesign or not
 ((STEP++))
-echo "$STEP/$STEPS. Checking if to codesign or not..."
+echo "$STEP/$STEPS. Checking if to codesign the application or not..."
 SIGNER_IDENTITY_APPLICATION="Developer ID Application: Foundation for Learning Equality, Inc. (H83B64B6AV)"
 if [ -z ${IS_BAMBOO+0} ]; then 
-    echo ".. Running on local machine, don't codesign!"
+    echo ".. Running on local machine, don't codesign the application!"
 else 
-    echo ".. Running on bamboo server, so MUST codesign..."
+    echo ".. Running on bamboo server, so MUST codesign the application..."
     # sign the .app file
     # unlock the keychain first so we can access the private key
     # security unlock-keychain -p $KEYCHAIN_PASSWORD
@@ -332,9 +332,25 @@ if [ $? -ne 0 ]; then
     echo ".. Abort!  Error building the .pkg file with '$PACKAGES_EXEC'."
     exit 1
 fi
+
+echo ".. Checking if to codesign the package or not..."
+SIGNER_IDENTITY_APPLICATION="Developer ID Application: Foundation for Learning Equality, Inc. (H83B64B6AV)"
+if [ -z ${IS_BAMBOO+0} ]; then 
+    echo ".. Running on local machine, don't codesign the package!"
+else 
+    echo ".. Running on bamboo server, so MUST codesign the package..."
+    # sign the .pkg file
+    # unlock the keychain first so we can access the private key
+    # security unlock-keychain -p $KEYCHAIN_PASSWORD
+    codesign -d -s "$SIGNER_IDENTITY_APPLICATION" --force "$PACKAGES_OUTPUT"
+    if [ $? -ne 0 ]; then
+        echo ".. Abort!  Error/s encountered codesigning '$PACKAGES_OUTPUT'."
+        exit 1
+    fi
+fi
+
 mv -v $PACKAGES_OUTPUT $OUTPUT_PATH
 echo "Congratulations! Your newly built installer is at '$OUTPUT_PATH/$KALITE_PACKAGES_NAME'."
-
 
 # TODO(cpauya): Check https://github.com/learningequality/ka-lite/pull/4630#issuecomment-155567771 for running kalite twice to start.
 

--- a/osx/release-docs/README.md
+++ b/osx/release-docs/README.md
@@ -15,8 +15,6 @@ It uses [PyRun](http://www.egenix.com/products/python/PyRun/) to isolate the KA 
 1. The installer will create the `/Applications/KA-Lite/` folder that contains the KA-Lite application, uninstaller tool, licence, readme, and release notes documents.
 1. The install process is quite lengthy because the installer had to copy assessment items and run some management commands including the setup process.  Please be patient.
 
-**Note:** A computer restart is needed to complete the installation.
-
 
 ## Using the KA Lite OS X Application
 
@@ -71,7 +69,7 @@ If you encounter issues, please file them at the [KA Lite Installers repository]
 
 Please note that we have tested this application on the following Mac OS X versions:
 
-* OS X El Capitan - version 10.11.1
+* OS X El Capitan - version 10.11.3
 * OS X Yosemite - version 10.10.5
 * OS X Mavericks - version 10.9.5
 

--- a/osx/release-docs/RELEASE_NOTES.md
+++ b/osx/release-docs/RELEASE_NOTES.md
@@ -7,7 +7,7 @@ Release Notes for KA Lite Mac OS X Application
 **Mac Installer**
 
 * NEW - We now support Mac OS X 10.11 El Capitan.
-* NEW - We now use a .pkg installer which uses a setup wizard GUI.  We also confirm to restart the computer to complete the installation.
+* NEW - We now use a .pkg installer which uses a setup wizard GUI.
 * NEW - We now bundle the `KA-Lite.app`, `README.md`, `LICENSE`, `RELEASE_NOTES.md`, and `KA-Lite_Uninstall.tool` script inside the `/Applications/KA-Lite/` folder.
 * NEW - We now have a pre-installation script that checks for a previous installation if it exists and does the following:
   - Remove `/Applications/KA-Lite/KA-Lite.app`.


### PR DESCRIPTION
Hi @aronasorman - this fixes #349.

We used `productbuild` to sign the resulting .pkg file.  Here`s a screenshot of the .pkg at work on Mac OS X El Capitan v10.11.3:
![screenshot 2016-02-02 15 47 48](https://cloud.githubusercontent.com/assets/175580/12744022/d47e6470-c9cc-11e5-8a8a-26b7ca9ac914.png)

I downloaded the Mac OS X installer at Bamboo here: http://dungeon.learningequality.org:8085/browse/KL-MT16-63/artifact

```bash
foxtrot-pro:ka-lite installers cyril$ pkgutil --check-signature KA-Lite.pkg
Package "KA-Lite.pkg":
   Status: signed by a certificate trusted by Mac OS X
   Certificate Chain:
    1. Developer ID Installer: Foundation for Learning Equality, Inc. (H83B64B6AV)
       SHA1 fingerprint: D5 8A 4C 0F F0 03 A1 86 D4 8E 63 07 1B 16 B7 71 5D EE 96 FA
       -----------------------------------------------------------------------------
    2. Developer ID Certification Authority
       SHA1 fingerprint: 3B 16 6C 3B 7D C4 B7 51 C9 FE 2A FA B9 13 56 41 E3 88 E1 86
       -----------------------------------------------------------------------------
    3. Apple Root CA
       SHA1 fingerprint: 61 1E 5B 66 2C 59 3A 08 FF 58 D1 4A E2 24 52 D1 98 DF 6C 60

foxtrot-pro:ka-lite installers cyril$ spctl --assess --type install KA-Lite.pkg
foxtrot-pro:ka-lite installers cyril$
```
You can also check the Bamboo logs for the details of the code and product signing activities: http://dungeon.learningequality.org:8085/browse/KL-MT16-63/log

Lastly, I've updated the documentation that comes with the installer to reflect the latest tested platforms.