### PR TITLE
Correct the check for number of KA Lite application instances during pre-install.

### DIFF
--- a/osx/README.md
+++ b/osx/README.md
@@ -49,7 +49,7 @@ This will require your admin password.
 
 Open the built package from the Getting Started section at `temp/output/KA-Lite.pkg` and follow the prompts.  For the curious, you can see installation logs in the `Console` application, just filter the entries with "KA-Lite".
 
-KA Lite will be installed in the `/Applications/KA-Lite/` folder along with the license, readme, release notes, and the support folder.  The `support` folder contains the content pack archive, the PyRun environment, and the scripts.
+KA Lite will be installed in the `/Applications/KA-Lite/` folder along with the uninstall.tool, license, readme, release notes, and the support folder.  The `support` folder contains the content pack archive, the PyRun environment, and the scripts.
 
 When testing locally built packages, we recommend using VirtualBox for a clean environment.  Making an OS X Virtual Machine for VirtualBox is beyond the scope of this document but you can easily find references on the net.
 
@@ -61,7 +61,7 @@ This will require your admin password.
 There are two ways to uninstall the KA Lite package:
 
 1. Load the KA Lite application then click its menu bar icon and select the Preferences menu item.  In the Preferences dialog, click on the "Uninstall KA Lite" button.
-1. Run the `ka-lite-remover.sh` in your Terminal to remove KA Lite.  It will confirm if you want to keep or delete your KA Lite data folder.
+1. Run the `/Applications/KA-Lite/KA-Lite_Uninstall.tool` in your Terminal to remove KA Lite.  It will confirm if you want to keep or delete your KA Lite data folder.
 
 
 ## Use Packages to build the KA Lite installer

--- a/osx/ka-lite-remover.sh
+++ b/osx/ka-lite-remover.sh
@@ -139,7 +139,7 @@ if [ $IS_PREINSTALL == true ]; then
     # Check if Mac process is running using Bash by process name
     PROCESS="/Applications/KA-Lite*"
     number=$(ps aux | grep "$PROCESS" | wc -l)
-    if [ $number -gt 0 ]; then
+    if [ $number -gt 1 ]; then
         msg "Installation cannot continue because KA Lite is running.  Please quit it first before installing."
         exit 1
     fi

--- a/osx/post_installation.sh
+++ b/osx/post_installation.sh
@@ -168,6 +168,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+
 ((STEP++))
 # TODO(arceduardvincent): Remove this step when the issue is solved.
 # Remove the old asset folder to be replaced by newer assets later.
@@ -185,8 +186,8 @@ else
 fi
 
 KALITE_ASSET_FOLDER="$KALITE_HOME/httpsrv/"
+msg "$STEP/$STEPS. Removing the old asset folder at '$KALITE_ASSET_FOLDER' to be replaced later..."
 if [ -d "$KALITE_ASSET_FOLDER" ]; then
-    msg "$STEP/$STEPS. Removing the old asset folder at $KALITE_ASSET_FOLDER..."
     rm -Rf "$KALITE_ASSET_FOLDER"
     if [ $? -ne 0 ]; then
         msg ".. Abort!  Error removing the $KALITE_ASSET_FOLDER."

--- a/osx/release-docs/README.md
+++ b/osx/release-docs/README.md
@@ -23,9 +23,8 @@ It uses [PyRun](http://www.egenix.com/products/python/PyRun/) to isolate the KA 
 
 ### To start the KA Lite server
 
-1. Launch `KA-Lite` from the `/Applications/KA-Lite/` folder.
-1. Click the `KA-Lite` icon in the menu bar and select the `Start KA Lite` menu option.
-1. When notified that KA Lite is running, click on the icon again and select the `Open in Browser` menu option - this should launch KA Lite in your preferred web browser.
+1. Launch `KA-Lite` from the `/Applications/KA-Lite/` folder.  It should auto-start the KA Lite server and notify you of it's status.
+1. When notified that KA Lite is running, click on the menu bar icon and select the `Open in Browser` menu option - this should launch KA Lite in your preferred web browser.
 
 
 ### Menu Options
@@ -57,14 +56,14 @@ It uses [PyRun](http://www.egenix.com/products/python/PyRun/) to isolate the KA 
 * Double-click the `/Applications/KA-Lite/KA-Lite_Uninstall.tool`, this is a bash script that will do the following:
   - uninstall `KA-Lite.app` and remove its dependencies, then unset the environment variables.
   - optionally remove the KA Lite data folder.
-* Alternatively, you can also use the Uninstall KA Lite button at the Preferences dialog of the KA Lite application.
+* Alternatively, you can also click the Uninstall KA Lite button at the Preferences dialog of the KA Lite application.  Check the "Delete KA Lite data folder" if you want to also remove your KA Lite data.
 
 
 ## Help and Logs
 
 To view the KA Lite installer and application logs, launch the `Console` application and filter by "ka-lite".  You can also view the KA Lite application logs in the `Preferences` dialog by clicking on the `Logs` tab.
 
-To view the KA Lite web server logs, open `~/.kalite/server.log` to view access and debug logs.
+To view the KA Lite web server logs, open `~/.kalite/server.log` to view access and debug logs.  If you have set a custom KA Lite data folder in the Preferences dialog, use this format: `$KALITE_HOME/server.log`.
 
 If you encounter issues, please file them at the [KA Lite repository](https://github.com/learningequality/ka-lite/issues/) or at the [KA Lite Installers repository](https://github.com/learningequality/installers).
 


### PR DESCRIPTION
## Summary

- Corrects the check for number of KA Lite application instances during pre-install and uninstall.
- Also restores the missing step 5 message during post-install at the Console app.
- Fixes #373
- Fixes #369


## Reviewer guidance

Download the [latest build 91 at Bamboo](http://dungeon.learningequality.org/browse/KL-MT16-91) which points to the hot fix branch for this PR.

/cc: @aronasorman @radinamatic 