### PR TITLE
Run a script to check if KA Lite is loaded before continuing with installation.

### DIFF
--- a/osx/KA-Lite-Packages/KA-Lite.pkgproj
+++ b/osx/KA-Lite-Packages/KA-Lite.pkgproj
@@ -694,7 +694,7 @@
 			ZW50LVN0eWxlLVR5cGUiIGNvbnRlbnQ9InRleHQvY3NzIj4KPHRp
 			dGxlPjwvdGl0bGU+CjxtZXRhIG5hbWU9IkdlbmVyYXRvciIgY29u
 			dGVudD0iQ29jb2EgSFRNTCBXcml0ZXIiPgo8bWV0YSBuYW1lPSJD
-			b2NvYVZlcnNpb24iIGNvbnRlbnQ9IjEzNDguMTciPgo8c3R5bGUg
+			b2NvYVZlcnNpb24iIGNvbnRlbnQ9IjE0MDQuMzQiPgo8c3R5bGUg
 			dHlwZT0idGV4dC9jc3MiPgo8L3N0eWxlPgo8L2hlYWQ+Cjxib2R5
 			Pgo8L2JvZHk+CjwvaHRtbD4K
 			</data>
@@ -733,10 +733,12 @@
 									<key>HIDDEN</key>
 									<false/>
 									<key>STATE</key>
-									<integer>1</integer>
+									<integer>0</integer>
 								</dict>
 								<key>PACKAGE_UUID</key>
 								<string>B4EC6D54-BE5C-4A01-9C5D-B46F57C5E5D9</string>
+								<key>REQUIREMENTS</key>
+								<array/>
 								<key>TITLE</key>
 								<array/>
 								<key>TOOLTIP</key>
@@ -753,6 +755,8 @@
 				</dict>
 				<key>INSTALLATION TYPE</key>
 				<integer>0</integer>
+				<key>MODE</key>
+				<integer>1</integer>
 			</dict>
 			<key>INSTALLATION_STEPS</key>
 			<array>
@@ -901,7 +905,49 @@
 		<key>PROJECT_REQUIREMENTS</key>
 		<dict>
 			<key>LIST</key>
-			<array/>
+			<array>
+				<dict>
+					<key>BEHAVIOR</key>
+					<integer>3</integer>
+					<key>DICTIONARY</key>
+					<dict>
+						<key>IC_REQUIREMENT_SCRIPT_ARGUMENTS</key>
+						<array/>
+						<key>IC_REQUIREMENT_SCRIPT_COMPARATOR</key>
+						<integer>0</integer>
+						<key>IC_REQUIREMENT_SCRIPT_EMBED</key>
+						<true/>
+						<key>IC_REQUIREMENT_SCRIPT_PATH</key>
+						<dict>
+							<key>PATH</key>
+							<string>../ka-lite-process-check.sh</string>
+							<key>PATH_TYPE</key>
+							<integer>1</integer>
+						</dict>
+						<key>IC_REQUIREMENT_SCRIPT_VALUE</key>
+						<integer>0</integer>
+					</dict>
+					<key>IC_REQUIREMENT_CHECK_TYPE</key>
+					<integer>0</integer>
+					<key>IDENTIFIER</key>
+					<string>fr.whitebox.Packages.requirement.scripts</string>
+					<key>MESSAGE</key>
+					<array>
+						<dict>
+							<key>LANGUAGE</key>
+							<string>English</string>
+							<key>SECONDARY_VALUE</key>
+							<string></string>
+							<key>VALUE</key>
+							<string>Found a loaded KA Lite application, please quit it first before running the installer.</string>
+						</dict>
+					</array>
+					<key>NAME</key>
+					<string>Result of External Script</string>
+					<key>STATE</key>
+					<true/>
+				</dict>
+			</array>
 			<key>POSTINSTALL_PATH</key>
 			<dict/>
 			<key>PREINSTALL_PATH</key>
@@ -909,12 +955,15 @@
 			<key>RESOURCES</key>
 			<array/>
 			<key>ROOT_VOLUME_ONLY</key>
-			<false/>
+			<true/>
 		</dict>
 		<key>PROJECT_SETTINGS</key>
 		<dict>
 			<key>ADVANCED_OPTIONS</key>
-			<dict/>
+			<dict>
+				<key>installer-script.options:allow-external-scripts</key>
+				<false/>
+			</dict>
 			<key>BUILD_FORMAT</key>
 			<integer>0</integer>
 			<key>BUILD_PATH</key>

--- a/osx/KA-Lite-Packages/docs/INTRODUCTION.rst.rtfd/TXT.rtf
+++ b/osx/KA-Lite-Packages/docs/INTRODUCTION.rst.rtfd/TXT.rtf
@@ -1,6 +1,6 @@
 {\rtf1\ansi\ansicpg1252\cocoartf1404\cocoasubrtf340
 {\fonttbl\f0\fswiss\fcharset0 Helvetica;}
-{\colortbl;\red255\green255\blue255;}
+{\colortbl;\red255\green255\blue255;\red217\green11\blue0;}
 \margl1440\margr1440\vieww10800\viewh7960\viewkind0
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\qc\partightenfactor0
 
@@ -21,4 +21,5 @@ All Rights Reserved\
 \
 \
 \
-NOTE: Make sure that the KA Lite application is not loaded before continuing.}
+
+\fs28 \cf2 NOTE: Make sure that the KA Lite application is not loaded before continuing.}

--- a/osx/KA-Lite-Packages/docs/README.rst.rtf
+++ b/osx/KA-Lite-Packages/docs/README.rst.rtf
@@ -7,7 +7,7 @@
 {\list\listtemplateid4\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{disc\}}{\leveltext\leveltemplateid301\'01\uc0\u8226 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listname ;}\listid4}
 {\list\listtemplateid5\listhybrid{\listlevel\levelnfc23\levelnfcn23\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\*\levelmarker \{disc\}}{\leveltext\leveltemplateid401\'01\uc0\u8226 ;}{\levelnumbers;}\fi-360\li720\lin720 }{\listname ;}\listid5}}
 {\*\listoverridetable{\listoverride\listid1\listoverridecount0\ls1}{\listoverride\listid2\listoverridecount0\ls2}{\listoverride\listid3\listoverridecount0\ls3}{\listoverride\listid4\listoverridecount0\ls4}{\listoverride\listid5\listoverridecount0\ls5}}
-\margl1440\margr1440\vieww26400\viewh19280\viewkind0
+\margl1440\margr1440\vieww54360\viewh29960\viewkind0
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 
 \f0\b\fs24 \cf0 \ul \ulc0 Release Notes for KA Lite 0.16.0
@@ -28,8 +28,9 @@ Other known issues:\
 \pard\tx220\tx720\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural\partightenfactor0
 \ls2\ilvl0\cf0 {\listtext	\'95	}NEW - We now support Mac OS X 10.11 El Capitan.\
 {\listtext	\'95	}NEW - We now use a .pkg installer which uses a setup wizard GUI.\
-{\listtext	\'95	}NEW - We now auto-load the application after installation.\
 {\listtext	\'95	}NEW - We now bundle the `KA-Lite.app`, `README.md`, `LICENSE`, `RELEASE_NOTES.md`, `KA-Lite_Uninstall.tool` script, and the `support` folder inside the `/Applications/KA-Lite/` folder.\
+{\listtext	\'95	}NEW - We now auto-load the application after installation.\
+{\listtext	\'95	}NEW - We now check if KA Lite is loaded and will not continue with the installation if it is.\
 {\listtext	\'95	}NEW - You can now use the `Console` utility application to view the KA-Lite installer and application logs.\
 {\listtext	\'95	}NEW - We now have a pre-installation script that checks for a previous installation if it exists and does the following:\
 \pard\tx940\tx1440\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li1440\fi-1440\pardirnatural\partightenfactor0
@@ -38,7 +39,7 @@ Other known issues:\
 {\listtext	\uc0\u8259 	}Remove `/Library/LaunchAgents/org.learningequality.kalite.plist`.\
 {\listtext	\uc0\u8259 	}Remove `/usr/bin/kalite` executable.\
 {\listtext	\uc0\u8259 	}Remove `/usr/local/bin/kalite` executable. \
-{\listtext	\uc0\u8259 	}Remove `/Applications/KA-Lite/support/` directory.\
+{\listtext	\uc0\u8259 	}Remove `/Applications/KA-Lite/` directory and its contents.\
 {\listtext	\uc0\u8259 	}Unset `KALITE_PYTHON` environment variable.\
 {\listtext	\uc0\u8259 	}Unset `KALITE_HOME` environment variable.\
 \pard\tx220\tx720\tx1120\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural\partightenfactor0
@@ -47,8 +48,9 @@ Other known issues:\
 \ls2\ilvl1\cf0 {\listtext	\uc0\u8259 	}Set `KALITE_PYTHON` environment variable.\
 {\listtext	\uc0\u8259 	}Symlink `kalite` executable to `/usr/local/bin/`.\
 {\listtext	\uc0\u8259 	}Bundle `KA-Lite.app`, `README.md`, `LICENSE`, `RELEASE_NOTES.md`, `KA-Lite_Uninstall.tool` script, and the `support` folder in the `/Applications/KA-Lite/` directory.\
-{\listtext	\uc0\u8259 	}We now use the `/Applications/KA-Lite/support/` folder which contains the `content/contentpacks/en.zip`, `pyrun`, and `scripts`. This is used as the KA Lite installer resources.   \
+{\listtext	\uc0\u8259 	}Put the `content/contentpacks/en.zip`, `pyrun`, and `scripts` inside the `/Applications/KA-Lite/support/` folder to be used as KA Lite installer resources.\
 {\listtext	\uc0\u8259 	}Run `kalite manage` commands like `syncdb --noinput`, `retrievecontentpack`, and `setup --noinput`.\
+{\listtext	\uc0\u8259 	}Auto-load the KA Lite application after a successful installation.\
 \pard\tx220\tx720\tx1120\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\li720\fi-720\pardirnatural\partightenfactor0
 \ls2\ilvl0\cf0 {\listtext	\'95	}REMOVED - We don't produce and use the `.dmg` disk image anymore.\
 {\listtext	\'95	}REMOVED - We removed the word `Monitor` in the installer name.\
@@ -66,6 +68,7 @@ Other known issues:\
 {\listtext	\'95	}NEW - User can now set a custom KA Lite data path, instead of the default `~/.kalite/`.\
 {\listtext	\'95	}FIXED - The startup time of the KA Lite server has been greatly reduced to just a few seconds.\
 {\listtext	\'95	}FIXED - We only load the `KA-Lite.app` if the `kalite` executable is available.\
+\ls3\ilvl0{\listtext	\'95	}FIXED - We now use the same version as the KA Lite web application for consistency.\
 {\listtext	\'95	}CHANGED - We changed `KA-Lite-Monitor.app` to `KA-Lite.app`.\
 {\listtext	\'95	}REMOVED - We removed the "Monitor" text from the application.\
 {\listtext	\'95	}REMOVED - We removed the `Advanced` tab and its contents.\

--- a/osx/KA-Lite/KA-Lite/AppDelegate.m
+++ b/osx/KA-Lite/KA-Lite/AppDelegate.m
@@ -913,6 +913,9 @@ NSString *getEnvVar(NSString *var) {
 
     // REF: http://stackoverflow.com/questions/99395/how-to-check-if-a-folder-exists-in-cocoa-objective-c
 
+    // This is needed to display the proper menu bar icon when applying the preferences.
+    [self setNewStatus:statusCouldNotDetermineStatus];
+    
     // MUST: Check if ~/Library/LaunchAgents/ path exists and create it if it doesn't.
     // We do this because some fresh install of Mac OS X does not have this folder.
     NSString *libraryLaunchAgentsPath = [NSString stringWithFormat:@"%@%@", NSHomeDirectory(), @"/Library/LaunchAgents/"];

--- a/osx/README.md
+++ b/osx/README.md
@@ -49,9 +49,13 @@ This will require your admin password.
 
 Open the built package from the Getting Started section at `temp/output/KA-Lite.pkg` and follow the prompts.  For the curious, you can see installation logs in the `Console` application, just filter the entries with "KA-Lite".
 
-KA Lite will be installed in the `/Applications/KA-Lite/` folder along with the uninstall.tool, license, readme, release notes, and the support folder.  The `support` folder contains the content pack archive, the PyRun environment, and the scripts.
+Click "Continue" when prompted about the "This package will run a program to determine if the software can be installed." message.
 
-When testing locally built packages, we recommend using VirtualBox for a clean environment.  Making an OS X Virtual Machine for VirtualBox is beyond the scope of this document but you can easily find references on the net.
+KA Lite will be installed in the `/Applications/KA-Lite/` folder along with the uninstall.tool, license, readme, release notes, and the support folder.  The `support` folder contains the English content pack archive, the PyRun environment, and the scripts.
+
+When testing locally-built packages, we recommend using VirtualBox for a clean environment.  Making an OS X Virtual Machine for VirtualBox is beyond the scope of this document but you can easily find references on the net.
+
+**Note:** Make sure that the KA Lite application is not loaded during installation.
 
 
 ## Uninstallation of the installed KA Lite package.

--- a/osx/ka-lite-process-check.sh
+++ b/osx/ka-lite-process-check.sh
@@ -17,8 +17,8 @@ msg "Checking for a loaded '$PROCESS'..."
 
 # REF: http://stackoverflow.com/a/1821897/845481 
 # Check if Mac process is running using Bash by process name
-number=$(ps aux | grep "$PROCESS" | wc -l)
-if [ $number -gt 1 ]; then
+number=$(ps aux | grep "$PROCESS" | grep -v "grep" | wc -l)
+if [ $number -gt 0 ]; then
     msg ".. Found a loaded '$PROCESS', please quit it before running the installer."
     exit 1
 fi

--- a/osx/ka-lite-process-check.sh
+++ b/osx/ka-lite-process-check.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# This script checks if KA Lite is loaded and exits with non-zero if it does.
+# This is required by the .pkg before it continues with the install process.
+
+
+# Print message in terminal and log for the Console application.
+function msg() {
+    echo "$1"
+    syslog -s -l alert "KA-Lite: $1"
+}
+
+
+PROCESS="/Applications/KA-Lite*"
+
+msg "Checking for a loaded '$PROCESS'..."
+
+# REF: http://stackoverflow.com/a/1821897/845481 
+# Check if Mac process is running using Bash by process name
+number=$(ps aux | grep "$PROCESS" | wc -l)
+if [ $number -gt 1 ]; then
+    msg ".. Found a loaded '$PROCESS', please quit it before running the installer."
+    exit 1
+fi
+
+msg ".. No loaded '$PROCESS' found."
+exit 0

--- a/osx/ka-lite-remover.sh
+++ b/osx/ka-lite-remover.sh
@@ -139,8 +139,8 @@ if [ $IS_PREINSTALL == true ]; then
     # REF: http://stackoverflow.com/a/1821897/845481 
     # Check if Mac process is running using Bash by process name
     PROCESS="$KALITE_DIR*"
-    number=$(ps aux | grep "$PROCESS" | wc -l)
-    if [ $number -gt 1 ]; then
+    number=$(ps aux | grep "$PROCESS" | grep -v "grep" | wc -l)
+    if [ $number -gt 0 ]; then
         msg "Installation cannot continue because KA Lite is running.  Please quit it first before installing."
         exit 1
     fi

--- a/osx/ka-lite-remover.sh
+++ b/osx/ka-lite-remover.sh
@@ -39,7 +39,8 @@ KALITE_PLIST="$ORG_LE_KALITE.plist"
 HOME_LAUNCH_AGENTS="$HOME/Library/LaunchAgents"
 ROOT_LAUNCH_AGENTS="/Library/LaunchAgents"
 KALITE_EXECUTABLE_PATH="$(which $KALITE)"
-KALITE_RESOURCES="/Applications/KA-Lite/support"
+KALITE_DIR="/Applications/KA-Lite"
+KALITE_RESOURCES="$KALITE_DIR/support"
 KALITE_USR_BIN_PATH="/usr/bin"
 KALITE_USR_LOCAL_BIN_PATH="/usr/local/bin"
 KALITE_UNINSTALL_SCRIPT="KA-Lite_Uninstall.tool"
@@ -137,7 +138,7 @@ function msg() {
 if [ $IS_PREINSTALL == true ]; then
     # REF: http://stackoverflow.com/a/1821897/845481 
     # Check if Mac process is running using Bash by process name
-    PROCESS="/Applications/KA-Lite*"
+    PROCESS="$KALITE_DIR*"
     number=$(ps aux | grep "$PROCESS" | wc -l)
     if [ $number -gt 1 ]; then
         msg "Installation cannot continue because KA Lite is running.  Please quit it first before installing."
@@ -150,7 +151,7 @@ SCRIPTPATH=`pwd`
 popd > /dev/null
 
 # Collect the directories and files to remove
-test -d /Applications/KA-Lite                   && REMOVE_FILES_ARRAY+=("/Applications/KA-Lite")
+test -d $KALITE_DIR                             && REMOVE_FILES_ARRAY+=("$KALITE_DIR")
 test -f $SCRIPTPATH/$KALITE_UNINSTALL_SCRIPT    && REMOVE_FILES_ARRAY+=("$SCRIPTPATH/$KALITE_UNINSTALL_SCRIPT")
 test -d $KALITE_RESOURCES                       && REMOVE_FILES_ARRAY+=("$KALITE_RESOURCES")
 test -f $KALITE_USR_LOCAL_BIN_PATH/$KALITE      && REMOVE_FILES_ARRAY+=("$KALITE_USR_LOCAL_BIN_PATH/$KALITE")
@@ -169,7 +170,7 @@ if [ $IS_PREINSTALL == false ]; then
     echo "                                                          "
     echo "https://learningequality.org/ka-lite/                     "
     echo "                                                          "
-    echo "     version $VERSION.x                                       "
+    echo "     version $VERSION.x                                   "
     echo "                                                          "
 fi
 

--- a/osx/release-docs/README.md
+++ b/osx/release-docs/README.md
@@ -11,11 +11,15 @@ It uses [PyRun](http://www.egenix.com/products/python/PyRun/) to isolate the KA 
 ## Install KA Lite
 
 1. Download the [KA Lite Mac OS X Installer for 0.16](http://pantry.learningequality.org/downloads/ka-lite/0.16/installers/mac/).
-1. Double-click the downloaded `KA-Lite.pkg` package and follow the setup wizard.  The installation requires admin privileges.
+1. Double-click the downloaded `KA-Lite.pkg` package and click "Continue" when prompted about the "This package will run a program to determine if the software can be installed." message.
+1. Follow the setup wizard.  The installation requires admin privileges.
+1. This package will run a program to determine if the software can be installed.
 1. The installer will create the `/Applications/KA-Lite/` folder that contains the KA-Lite application, uninstall tool, licence, readme, release notes, and the support folder.
 1. The install process is quite lengthy because the installer had to copy content items and run some management commands including the setup process.  Please be patient.
 1. After a successful installation, the KA Lite application will be auto-loaded and it will also auto-start the KA Lite web server.
 1. You should see the notification "Running, you can now click on 'Open in Browser' menu.".
+
+**Note:** Make sure that the KA Lite application is not loaded during installation.
 
 
 ## Using the KA Lite OS X Application

--- a/osx/release-docs/README.md
+++ b/osx/release-docs/README.md
@@ -42,16 +42,14 @@ It uses [PyRun](http://www.egenix.com/products/python/PyRun/) to isolate the KA 
 
 ### How to set a custom KA Lite data folder:
 
- 1. Stop the KA Lite server from running.
- 2. Set your custom KA Lite data folder in the `Preferences` dialog.
- 3. Click `Apply`.  This will update the `KALITE_HOME` environment variable.
- 4. Launch a new Terminal session to use the updated `KALITE_HOME` environment variable.
- 5. Run `kalite manage syncdb --noinput`.
- 7. Run `kalite manage setup --noinput`.
- 8. Run `kalite manage retrievecontentpack local en /Applications/KA-Lite/support/content/contentpacks/en.zip`.
- 9. Start the server again by clicking on `Start KA Lite` in the menu option.
+**Note:** To prevent loss of data, backup your existing KA Lite data folder first then manually create the new data folder.
 
-**Note:** You can specify another content pack archive that you've downloaded from http://pantry.learningequality.org/downloads/ka-lite at the `retrievecontentpack` step above.  Make sure you download the content pack archive for the installed version of KA Lite.
+1. Stop the KA Lite server if running.
+2. Select your custom KA Lite data folder in the `Preferences` dialog.
+3. Click `Apply`.  This will update the `KALITE_HOME` environment variable.
+4. Start the server again by clicking on `Start KA Lite` in the menu option.  This will take a few minutes to complete and you will be notified when KA Lite is already running.
+
+**Note:** Under Mac OS X El Capitan, you have to press `Cmd+Shift+N` to create a folder in the path control panel because it does not display a `New Folder` button.  We suggest you create the destination data folder before doing this.
 
 
 ## Uninstall KA Lite

--- a/osx/release-docs/RELEASE_NOTES.md
+++ b/osx/release-docs/RELEASE_NOTES.md
@@ -10,6 +10,7 @@ Release Notes for KA Lite Mac OS X Application
 * NEW - We now use a .pkg installer which uses a setup wizard GUI.
 * NEW - We now bundle the `KA-Lite.app`, `README.md`, `LICENSE`, `RELEASE_NOTES.md`, `KA-Lite_Uninstall.tool` script, and the `support` folder inside the `/Applications/KA-Lite/` folder.
 * NEW - We now auto-load the application after installation.
+* NEW - We now check if KA Lite is loaded and will not continue with the installation if it is.
 * NEW - You can now use the `Console` utility application to view the KA-Lite installer and application logs.
 * NEW - We now have a pre-installation script that checks for a previous installation if it exists and does the following:
   - Remove `/Applications/KA-Lite/KA-Lite.app`.
@@ -17,15 +18,16 @@ Release Notes for KA Lite Mac OS X Application
   - Remove `/Library/LaunchAgents/org.learningequality.kalite.plist`.
   - Remove `/usr/bin/kalite` executable.
   - Remove `/usr/local/bin/kalite` executable. 
-  - Remove `/Applications/KA-Lite/support/` directory.
+  - Remove `/Applications/KA-Lite/` directory and its contents.
   - Unset `KALITE_PYTHON` environment variable.
   - Unset `KALITE_HOME` environment variable.
 * NEW - We now have a post-installation script that does the following:
   - Set `KALITE_PYTHON` environment variable.
   - Symlink `kalite` executable to `/usr/local/bin/`.
   - Bundle `KA-Lite.app`, `README.md`, `LICENSE`, `RELEASE_NOTES.md`, `KA-Lite_Uninstall.tool` script, and the `support` folder in the `/Applications/KA-Lite/` directory.
-  - We now use the `/Applications/KA-Lite/support/` folder which contains the `content/contentpacks/en.zip`, `pyrun`, and `scripts`. This is used as the KA Lite installer resources.  
+  - Put the `content/contentpacks/en.zip`, `pyrun`, and `scripts` inside the `/Applications/KA-Lite/support/` folder to be used as KA Lite installer resources.
   - Run `kalite manage` commands like `syncdb --noinput`, `retrievecontentpack`, and `setup --noinput`.
+  - Auto-load the KA Lite application after a successful installation.
 * REMOVED - We don't produce and use the `.dmg` disk image anymore.
 * REMOVED - We removed the word `Monitor` in the installer name.
 
@@ -37,12 +39,12 @@ Release Notes for KA Lite Mac OS X Application
 * NEW - User can now set a custom KA Lite data path, instead of the default `~/.kalite/`.
 * FIXED - The startup time of the KA Lite server has been greatly reduced to just a few seconds.
 * FIXED - We only load the `KA-Lite.app` if the `kalite` executable is available.
+* FIXED - We now use the same version as the KA Lite web application for consistency.
 * CHANGED - We changed `KA-Lite-Monitor.app` to `KA-Lite.app`.
 * REMOVED - We removed the "Monitor" text from the application.
 * REMOVED - We removed the `Advanced` tab and its contents.
 * REMOVED - We removed the automatic creation of admin account during setup.
  
-
 **Mac Uninstaller**
 
 * NEW - User can uninstall `KA-Lite.app` and it's dependencies using the `KA-Lite_Uninstall.tool` script.


### PR DESCRIPTION
## Summary

- Added a script to check for a running KA Lite and use that as a requirement for the installer before continuing.
- Fixes #369 
- Also fixes #380
- Also fixes https://github.com/learningequality/ka-lite/issues/4964


## TODO
- [x] Added/updated the documentation.


## Reviewer guidance

Download the [build 95 on Bamboo](http://dungeon.learningequality.org/browse/KL-MT16-95) to test this hot fix.

### To reproduce (preferrably in a VM)

1. If you don't have KA Lite installed, download and install a previous KA Lite OS X installer from http://pantry.learningequality.org/downloads/ka-lite/0.15/installers/mac/.
1. Run the KA Lite application, no need to input an admin account, just leave it running.
1. Install the .pkg from Bamboo as per above.
1. Click the Continue button when prompted with the "This package will run a program to determine if the software can be installed." message.
1. It should notify you with a "Found a loaded KA Lite application, please quit it first before running the installer." message.


## Screenshots

![ka-lite-prevent-upgrade-3](https://cloud.githubusercontent.com/assets/175580/13953788/a58e32b2-f078-11e5-8760-b6dae476e89d.gif)

/cc: @radinamatic @aronasorman 