### PR TITLE
Run `pip install -r requirements_sphinx.txt` to fix the failing OS X build.

### DIFF
--- a/osx/build.sh
+++ b/osx/build.sh
@@ -270,6 +270,16 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+PIP_CMD="$PYRUN_PIP install -r requirements_sphinx.txt"
+# TODO(cpauya): Streamline this to pip install only the needed modules/executables for `make dist` below.
+cd "$KA_LITE_DIR"
+echo ".. Running $PIP_CMD..."
+$PIP_CMD
+if [ $? -ne 0 ]; then
+    echo ".. Abort!  Error/s encountered running '$PIP_CMD'."
+    exit 1
+fi
+
 
 ((STEP++))
 echo "$STEP/$STEPS. Running 'make dist'..."

--- a/osx/post_installation.sh
+++ b/osx/post_installation.sh
@@ -13,11 +13,12 @@
 # 4. Run shebangcheck script that checks the python/pyrun interpreter to use.
 # 5. Remove the old asset folder to be replaced by newer assets later.
 # 6. Run kalite manage syncdb --noinput.
-# 8. Run kalite manage setup --noinput.
-# 7. Run kalite manage retrievecontentpack local en path-to-en.zip.
-# 9. Change the owner of the ~/.kalite/ folder and .plist file to current user.
-# 10. Set the KALITE_PYTHON env var for the user doing the install so we don't need to restart after installation.
-# 11. Create a copy of ka-lite-remover.sh and name it as KA-Lite_Uninstall.tool.
+# 7. Run kalite manage setup --noinput.
+# 8. Run kalite manage collectstatic --noinput.
+# 9. Run kalite manage retrievecontentpack local en path-to-en.zip.
+# 10. Change the owner of the ~/.kalite/ folder and .plist file to current user.
+# 11. Set the KALITE_PYTHON env var for the user doing the install so we don't need to restart after installation.
+# 12. Create a copy of ka-lite-remover.sh and name it as KA-Lite_Uninstall.tool.
 
 
 #----------------------------------------------------------------------
@@ -26,7 +27,7 @@
 SCRIPTPATH=$( cd $(dirname $0) ; pwd -P )
 
 STEP=0
-STEPS=11
+STEPS=12
 
 KALITE_SHARED="/Applications/KA-Lite/support"
 KALITE_DIR="$HOME/.kalite"
@@ -204,6 +205,11 @@ $BIN_PATH/kalite manage syncdb --noinput
 ((STEP++))
 msg "$STEP/$STEPS. Running kalite manage setup --noinput..."
 $BIN_PATH/kalite manage setup --noinput
+
+
+((STEP++))
+msg "$STEP/$STEPS. Running kalite manage collectstatic --noinput..."
+$BIN_PATH/kalite manage collectstatic --noinput
 
 
 # Use `kalite manage retrievecontentpack local en path-to-en.zip`.


### PR DESCRIPTION
## Summary

Run `pip install -r requirements_sphinx.txt` to fix the failing OS X build.

- Fixes #382
- Also Fixes learningequality/ka-lite#5054 by running `pyrun manage collectstatic --noinput` during post-install.

## Reviewer guidance

* Download the [artifact from build 104 at Bamboo](http://dungeon.learningequality.org/browse/KL-MT16-104) to test this PR.