### PR TITLE
Modify the instructions in building "KALiteSetup.exe" in windows README.

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -26,7 +26,8 @@ To build in Linux, first install `wine`. These directions assume you're building
 skip using msys and use bash instead.
 
 * Clone this repository;
-* Download ka-lite-static sdist zipfile from https://pypi.python.org/pypi/ka-lite-static/
+* Clone `ka-lite` repository from https://github.com/learningequality/ka-lite to this directory.
+* Download ka-lite-static sdist zipfile from https://pypi.python.org/pypi/ka-lite-static/ to this directory.
 * Download the English content pack `en.zip` file to this directory. Look for it in [the pantry](http://pantry.learningequality.org/downloads/).
 * Set the environment variable KALITE_BUILD_VERSION to the desired version for the installer, e.g. `0.16.0`.
   This should match the version in the sdist *exactly*, so `ka-lite-static-0.17.3` means that `KALITE_BUILD_VERSION`


### PR DESCRIPTION
## Summary

@MCGallaspy, This fixes #398 

## TODO

- [x] Add an instruction in building `KALiteSetup.exe`.
- [x] After downloading `ka-lite-static sdist zipfile`, specify the directory where to place it.


## Documentation

https://github.com/learningequality/installers/tree/master/windows