### PR TITLE
Temporary fix of pyrun that failed to install setuptools.

### DIFF
--- a/osx/build.sh
+++ b/osx/build.sh
@@ -206,7 +206,8 @@ fi
 ((STEP++))
 echo "$STEP/$STEPS. Checking Pyrun..."
 
-INSTALL_PYRUN_URL="https://downloads.egenix.com/python/install-pyrun"
+# TODO(arceduardvincent): Update the pyrun url if the "Failed to install setuptools" issue is fix.
+INSTALL_PYRUN_URL="https://downloads.egenix.com/python/index/ucs2/egenix-pyrun/2.2.0/install-pyrun?filename=install-pyrun"
 INSTALL_PYRUN="$WORKING_DIR/install-pyrun.sh"
 PYRUN_NAME="pyrun-2.7"
 PYRUN_DIR="$WORKING_DIR/$PYRUN_NAME"


### PR DESCRIPTION
## Summary
- Fixes #401
- The new release of `install-pyrun.sh` is creating an issue when building the KA-Lite OS X installer.
To fix this issue I use the older versions of eGenix PyRun prior to the latest release.

## Screenshots
![screen shot 2016-06-09 at 5 20 52 am](https://cloud.githubusercontent.com/assets/4099119/15911325/f9dfcd00-2e01-11e6-8b44-1cd5e209946a.png)

