### PR TITLE
Do not depend on possibly problematic systemd library

### DIFF
--- a/debian/debian/init-service
+++ b/debian/debian/init-service
@@ -2,7 +2,7 @@
 
 # Author: Foundation for Learning Equality
 #
-# /etc/init.d/kalite
+# /etc/init.d/ka-lite
 
 ### BEGIN INIT INFO
 # Provides:          kalite
@@ -23,7 +23,9 @@ fi
 
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
 
-. /lib/lsb/init-functions
+# Commented out because it causes "no such file or directory" error on Raspbian default install
+# ...not that the file is missing, some other component fails
+# . /lib/lsb/init-functions
 
 . /etc/default/ka-lite
 
@@ -43,7 +45,7 @@ case "$1" in
     su $KALITE_USER -s /bin/sh -c "$KALITE_COMMAND status $KALILTE_OPTS"
     ;;
   *)
-    log_success_msg "Usage: /etc/init.d/kalite {start|stop|restart|status}"
+    echo "Usage: /etc/init.d/kalite {start|stop|restart|status}" >&2
     exit 1
 esac
 


### PR DESCRIPTION
## Summary

Not released yet

On a vanilla Raspbian installation, I found the system service causing this issue, it was unseen on previous installations of Raspbian Jessie, so I can't say for sure what has gone wrong.

```
pi@raspberrypi:~ $ sudo /etc/init.d/ka-lite restart
[....] Restarting ka-lite (via systemctl): ka-lite.serviceFailed to restart ka-lite.service: Unit ka-lite.service failed to load: No such file or directory. failed! 
```

## TODO

> PR is considered WIP (work in progress), until all TODOs are marked.

- [ ] Added entry to CHANGELOG.rst

## Reviewer guidance
