### PR TITLE
Use well-known location for bundled english content pack.

### DIFF
--- a/windows/README.md
+++ b/windows/README.md
@@ -27,7 +27,7 @@ skip using msys and use bash instead.
 
 * Clone this repository;
 * Download ka-lite-static sdist whl file from https://pypi.python.org/pypi/ka-lite-static/ to this directory.
-* Download the English content pack `en.zip` file to this directory. Look for it in [the pantry](http://pantry.learningequality.org/downloads/).
+* Download and rename the English content pack from `en.zip` to `contentpack-0.17.en.zip` to this directory. Look for it in [the pantry](http://pantry.learningequality.org/downloads/)
 * Set the environment variable KALITE_BUILD_VERSION to the desired version for the installer, e.g. `0.16.0`.
   This should match the version in the sdist *exactly*, so `ka-lite-static-0.17.3` means that `KALITE_BUILD_VERSION`
   should have the value `0.17.3`.

--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -38,7 +38,7 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 
 [Files]
 Source: "..\ka_lite_static-*.whl"; DestDir: "{app}\ka-lite"
-Source: "..\en.zip"; DestDir: "{app}"
+Source: "..\*en.zip"; DestDir: "{app}\ka-lite\preseed"
 Source: "..\scripts\*.bat"; DestDir: "{app}\ka-lite\scripts\"
 Source: "..\gui-packed\KA Lite.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\gui-packed\guitools.vbs"; DestDir: "{app}"; Flags: ignoreversion
@@ -461,6 +461,12 @@ begin
         'KALITE_PYTHON',
         pythonPath
     );
+    RegWriteStringValue(
+        HKLM,
+        'System\CurrentControlSet\Control\Session Manager\Environment',
+        'KALITE_DIR',
+        ExpandConstant('{app}') + '\ka-lite'
+    );
     
 end;
 
@@ -502,15 +508,6 @@ begin
   result := True;
 end;
 
-procedure DoSetup;
-var
-    retCode: integer;
-begin
-    { Used to have more responsibility, but we delegated those to the app itself! }
-    { Unpacks the English content pack. }
-    Exec(ExpandConstant('{cmd}'), '/S /C "' + ExpandConstant('"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat"') + ' manage syncdb --noinput"', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, retCode);
-    Exec(ExpandConstant('{cmd}'), '/S /C "' + ExpandConstant('"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat"') + ' manage retrievecontentpack local en en.zip --foreground"', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, retCode);
-end;
 
 procedure CurStepChanged(CurStep: TSetupStep);
 var
@@ -570,9 +567,6 @@ begin
         if installFlag then
         begin
             HandlePipSetup();
-            begin
-                DoSetup;
-            end;
         end;
     end;
 end;
@@ -588,5 +582,10 @@ begin
         HKLM,
         'System\CurrentControlSet\Control\Session Manager\Environment',
         'KALITE_SCRIPT_DIR'
+    )
+    RegDeleteValue(
+        HKLM,
+        'System\CurrentControlSet\Control\Session Manager\Environment',
+        'KALITE_DIR'
     )
 end;

--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -37,7 +37,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "..\ka_lite_static-*.whl"; DestDir: "{app}\ka-lite"
+Source: "..\ka_lite*.whl"; DestDir: "{app}\ka-lite"
 Source: "..\*en.zip"; DestDir: "{app}\ka-lite\preseed"
 Source: "..\scripts\*.bat"; DestDir: "{app}\ka-lite\scripts\"
 Source: "..\gui-packed\KA Lite.exe"; DestDir: "{app}"; Flags: ignoreversion
@@ -423,14 +423,19 @@ begin
     end;
 end;
 
+function GetPipDir(Value: string): String;
+begin
+    result := ExtractFileDir(GetPipPath);
+end;
+
 procedure DoSetup;
 var
     retCode: integer;
 begin
     { Used to have more responsibility, but we delegated those to the app itself! }
     { Unpacks the English content pack. }
-    Exec(ExpandConstant('{cmd}'), '/S /C "' + ExpandConstant('"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat"') + ' manage syncdb --noinput"', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, retCode);
-    Exec(ExpandConstant('{cmd}'), '/S /C "' + ExpandConstant('"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat"') + ' manage collectstatic --noinput"', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, retCode);
+    Exec(ExpandConstant('{cmd}'), '/k " ' + '"' +  ExpandConstant('{app}')+'\ka-lite\scripts\reset-env-vars.bat"' + ' && ' + ExpandConstant('"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat"') + ' manage setup --noinput"', ExpandConstant('{app}'), SW_SHOW, ewWaitUntilTerminated, retCode);
+    
 end;
 
 procedure HandlePipSetup;
@@ -445,7 +450,7 @@ begin
     PipPath := GetPipPath;
     if PipPath = '' then
         exit;
-    PipCommand := 'install "' + ExpandConstant('{app}') + '\ka-lite\ka_lite_static-' + '{#TargetVersion}' + '-py2-none-any' + '.whl"';
+    PipCommand := 'install "' + ExpandConstant('{app}') + '\ka-lite\ka_lite-' + '{#TargetVersion}' + '-py2-none-any' + '.whl"';
 
     MsgBox('Setup will now install kalite source files to your Python site-packages.', mbInformation, MB_OK);
     if not Exec(PipPath, PipCommand, '', SW_SHOW, ewWaitUntilTerminated, ErrorCode) then

--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -423,6 +423,16 @@ begin
     end;
 end;
 
+procedure DoSetup;
+var
+    retCode: integer;
+begin
+    { Used to have more responsibility, but we delegated those to the app itself! }
+    { Unpacks the English content pack. }
+    Exec(ExpandConstant('{cmd}'), '/S /C "' + ExpandConstant('"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat"') + ' manage syncdb --noinput"', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, retCode);
+    Exec(ExpandConstant('{cmd}'), '/S /C "' + ExpandConstant('"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat"') + ' manage collectstatic --noinput"', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, retCode);
+end;
+
 procedure HandlePipSetup;
 var
     PipCommand: string;
@@ -461,6 +471,7 @@ begin
         'KALITE_PYTHON',
         pythonPath
     );
+    DoSetup;
     RegWriteStringValue(
         HKLM,
         'System\CurrentControlSet\Control\Session Manager\Environment',
@@ -507,7 +518,6 @@ begin
   ShellExec('open', ExpandConstant('{app}') + '\ka-lite\bin\windows\kalite.bat stop', '', '', SW_HIDE, ewWaitUntilTerminated, ErrorCode);
   result := True;
 end;
-
 
 procedure CurStepChanged(CurStep: TSetupStep);
 var

--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -432,10 +432,8 @@ procedure DoSetup;
 var
     retCode: integer;
 begin
-    { Used to have more responsibility, but we delegated those to the app itself! }
-    { Unpacks the English content pack. }
-    Exec(ExpandConstant('{cmd}'), '/k " ' + '"' +  ExpandConstant('{app}')+'\ka-lite\scripts\reset-env-vars.bat"' + ' && ' + ExpandConstant('"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat"') + ' manage setup --noinput"', ExpandConstant('{app}'), SW_SHOW, ewWaitUntilTerminated, retCode);
-    
+    { Run kalite manage setup command. }
+    Exec(ExpandConstant('{cmd}'), '/S /C " ' + '"' +  ExpandConstant('{app}')+'\ka-lite\scripts\reset-env-vars.bat"' + ' && ' + ExpandConstant('"{reg:HKLM\System\CurrentControlSet\Control\Session Manager\Environment,KALITE_SCRIPT_DIR}\kalite.bat"') + ' manage setup --noinput"', ExpandConstant('{app}'), SW_HIDE, ewWaitUntilTerminated, retCode);
 end;
 
 procedure HandlePipSetup;
@@ -452,14 +450,14 @@ begin
         exit;
     PipCommand := 'install "' + ExpandConstant('{app}') + '\ka-lite\ka_lite-' + '{#TargetVersion}' + '-py2-none-any' + '.whl"';
 
-    MsgBox('Setup will now install kalite source files to your Python site-packages.', mbInformation, MB_OK);
+    WizardForm.StatusLabel.Caption := 'Setup wizard is copying files. This may take a while, please wait...';
+    WizardForm.StatusLabel.Font.Style := [fsBold];
     if not Exec(PipPath, PipCommand, '', SW_SHOW, ewWaitUntilTerminated, ErrorCode) then
     begin
       MsgBox('Critical error.' #13#13 'Dependencies have failed to install. Error Number: ' + IntToStr(ErrorCode), mbInformation, MB_OK);
       forceCancel := True;
       WizardForm.Close;
     end
-
     { Must set this environment variable so the systray executable knows where to find the installed kalite.bat script}
     { Should by in the same directory as pip.exe, e.g. 'C:\Python27\Scripts' }
     RegWriteStringValue(
@@ -476,13 +474,14 @@ begin
         'KALITE_PYTHON',
         pythonPath
     );
-    DoSetup;
     RegWriteStringValue(
         HKLM,
         'System\CurrentControlSet\Control\Session Manager\Environment',
         'KALITE_DIR',
         ExpandConstant('{app}') + '\ka-lite'
     );
+    DoSetup;
+
     
 end;
 

--- a/windows/installer-source/KaliteSetupScript.iss
+++ b/windows/installer-source/KaliteSetupScript.iss
@@ -37,7 +37,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
 [Files]
-Source: "..\ka_lite*.whl"; DestDir: "{app}\ka-lite"
+Source: "..\ka_lite_static-*.whl"; DestDir: "{app}\ka-lite"
 Source: "..\*en.zip"; DestDir: "{app}\ka-lite\preseed"
 Source: "..\scripts\*.bat"; DestDir: "{app}\ka-lite\scripts\"
 Source: "..\gui-packed\KA Lite.exe"; DestDir: "{app}"; Flags: ignoreversion
@@ -448,11 +448,11 @@ begin
     PipPath := GetPipPath;
     if PipPath = '' then
         exit;
-    PipCommand := 'install "' + ExpandConstant('{app}') + '\ka-lite\ka_lite-' + '{#TargetVersion}' + '-py2-none-any' + '.whl"';
+    PipCommand := 'install "' + ExpandConstant('{app}') + '\ka-lite\ka_lite_static-' + '{#TargetVersion}' + '-py2-none-any.whl"';
 
     WizardForm.StatusLabel.Caption := 'Setup wizard is copying files. This may take a while, please wait...';
     WizardForm.StatusLabel.Font.Style := [fsBold];
-    if not Exec(PipPath, PipCommand, '', SW_SHOW, ewWaitUntilTerminated, ErrorCode) then
+    if not Exec(PipPath, PipCommand, '', SW_HIDE, ewWaitUntilTerminated, ErrorCode) then
     begin
       MsgBox('Critical error.' #13#13 'Dependencies have failed to install. Error Number: ' + IntToStr(ErrorCode), mbInformation, MB_OK);
       forceCancel := True;

--- a/windows/scripts/reset-env-vars.bat
+++ b/windows/scripts/reset-env-vars.bat
@@ -1,0 +1,55 @@
+@echo off
+::
+:: REF:: https://github.com/matthewvukomanovic/pcsetup/blob/master/RefreshEnv.cmd
+::
+:: Batch file to read environment variables from registry and
+:: set session variables to these values.
+::
+:: With this batch file, there should be no need to reload command
+:: environment every time you want environment changes to propagate
+
+echo | set /p dummy="Reading environment variables from registry. Please wait... "
+
+goto main
+
+:: Set one environment variable from registry key
+:SetFromReg
+    "%WinDir%\System32\Reg" QUERY "%~1" /v "%~2" > "%TEMP%\_envset.tmp" 2>NUL
+    for /f "usebackq skip=2 tokens=2,*" %%A IN ("%TEMP%\_envset.tmp") do (
+        echo/set %~3=%%B
+    )
+    goto :EOF
+
+:: Get a list of environment variables from registry
+:GetRegEnv
+    "%WinDir%\System32\Reg" QUERY "%~1" > "%TEMP%\_envget.tmp"
+    for /f "usebackq skip=2" %%A IN ("%TEMP%\_envget.tmp") do (
+        if /I not "%%~A"=="Path" (
+            call :SetFromReg "%~1" "%%~A" "%%~A"
+        )
+    )
+    goto :EOF
+
+:main
+    echo/@echo off >"%TEMP%\_env.cmd"
+
+    :: Slowly generating final file
+    call :GetRegEnv "HKLM\System\CurrentControlSet\Control\Session Manager\Environment" >> "%TEMP%\_env.cmd"
+    call :GetRegEnv "HKCU\Environment">>"%TEMP%\_env.cmd" >> "%TEMP%\_env.cmd"
+
+    :: Special handling for PATH - mix both User and System
+    call :SetFromReg "HKLM\System\CurrentControlSet\Control\Session Manager\Environment" Path Path_HKLM >> "%TEMP%\_env.cmd"
+    call :SetFromReg "HKCU\Environment" Path Path_HKCU >> "%TEMP%\_env.cmd"
+
+    :: Caution: do not insert space-chars before >> redirection sign
+    echo/set Path=%%Path_HKLM%%;%%Path_HKCU%% >> "%TEMP%\_env.cmd"
+
+    :: Cleanup
+    del /f /q "%TEMP%\_envset.tmp" 2>nul
+    del /f /q "%TEMP%\_envget.tmp" 2>nul
+
+    :: Set these variables
+    call "%TEMP%\_env.cmd"
+
+    echo | set /p dummy="Done"
+    echo .


### PR DESCRIPTION
## Summary

> This will extract the bundled english content pack during first run of `kalite start command.`


## Issues addressed

Fixes #438 

@radinamatic here's the [windows installer](https://drive.google.com/open?id=0B5Tyi-tRKOFMNFFvdWUxMlpVM3M) to test this PR.

/cc @benjaoming  @radinamatic 